### PR TITLE
Fix for "Mmm. DD" abbreviation with period syntax

### DIFF
--- a/parsedatetime/__init__.py
+++ b/parsedatetime/__init__.py
@@ -1217,9 +1217,8 @@ class Calendar:
         @return: tuple of: modified C{sourceTime} and the result flag
         """
 
-        # patch to address an issue with "Aug. 25" instead of "Aug 25" without breaking "mm.dd.yyyy"
         datetimeString = re.sub(r'(\w)(\.)(\s)', r'\1\3', datetimeString)
-        
+
         if sourceTime:
             if isinstance(sourceTime, datetime.datetime):
                 log.debug('coercing datetime to timetuple')

--- a/parsedatetime/tests/TestSimpleDateTimes.py
+++ b/parsedatetime/tests/TestSimpleDateTimes.py
@@ -100,11 +100,12 @@ class test(unittest.TestCase):
         self.assertTrue(_compareResults(self.cal.parse('8/25/06',         start), (target, 1)))
         self.assertTrue(_compareResults(self.cal.parse('August 25, 2006', start), (target, 1)))
         self.assertTrue(_compareResults(self.cal.parse('Aug 25, 2006',    start), (target, 1)))
+        self.assertTrue(_compareResults(self.cal.parse('Aug. 25, 2006',   start), (target, 1)))
         self.assertTrue(_compareResults(self.cal.parse('August 25 2006',  start), (target, 1)))
         self.assertTrue(_compareResults(self.cal.parse('Aug 25 2006',     start), (target, 1)))
+        self.assertTrue(_compareResults(self.cal.parse('Aug. 25 2006',    start), (target, 1)))
         self.assertTrue(_compareResults(self.cal.parse('25 August 2006',  start), (target, 1)))
         self.assertTrue(_compareResults(self.cal.parse('25 Aug 2006',     start), (target, 1)))
-        self.assertTrue(_compareResults(self.cal.parse('Aug. 25 2006',    start), (target, 1)))
 
         if self.mth > 8 or (self.mth == 8 and self.dy > 25):
             target = datetime.datetime(self.yr + 1, 8, 25,  self.hr, self.mn, self.sec).timetuple()
@@ -116,6 +117,7 @@ class test(unittest.TestCase):
         self.assertTrue(_compareResults(self.cal.parse('08/25',     start), (target, 1)))
         self.assertTrue(_compareResults(self.cal.parse('August 25', start), (target, 1)))
         self.assertTrue(_compareResults(self.cal.parse('Aug 25',    start), (target, 1)))
+        self.assertTrue(_compareResults(self.cal.parse('Aug. 25',   start), (target, 1)))
 
 
     def testLeapDays(self):
@@ -156,8 +158,10 @@ class test(unittest.TestCase):
 
         self.assertTrue(_compareResults(self.cal.parse('August 22nd, 2008', start), (target, 1)))
         self.assertTrue(_compareResults(self.cal.parse('Aug 22nd, 2008',    start), (target, 1)))
+        self.assertTrue(_compareResults(self.cal.parse('Aug. 22nd, 2008',   start), (target, 1)))
         self.assertTrue(_compareResults(self.cal.parse('August 22nd 2008',  start), (target, 1)))
         self.assertTrue(_compareResults(self.cal.parse('Aug 22nd 2008',     start), (target, 1)))
+        self.assertTrue(_compareResults(self.cal.parse('Aug. 22nd 2008',    start), (target, 1)))
         self.assertTrue(_compareResults(self.cal.parse('22nd August 2008',  start), (target, 1)))
         self.assertTrue(_compareResults(self.cal.parse('22nd Aug 2008',     start), (target, 1)))
 
@@ -174,15 +178,19 @@ class test(unittest.TestCase):
 
         self.assertTrue(_compareResults(self.cal.parse('August 23rd, 2008', start), (target, 1)))
         self.assertTrue(_compareResults(self.cal.parse('Aug 23rd, 2008',    start), (target, 1)))
+        self.assertTrue(_compareResults(self.cal.parse('Aug. 23rd, 2008',   start), (target, 1)))
         self.assertTrue(_compareResults(self.cal.parse('August 23rd 2008',  start), (target, 1)))
         self.assertTrue(_compareResults(self.cal.parse('Aug 23rd 2008',     start), (target, 1)))
+        self.assertTrue(_compareResults(self.cal.parse('Aug. 23rd 2008',    start), (target, 1)))
 
         target = datetime.datetime(2008, 8, 25,  self.hr, self.mn, self.sec).timetuple()
 
         self.assertTrue(_compareResults(self.cal.parse('August 25th, 2008', start), (target, 1)))
         self.assertTrue(_compareResults(self.cal.parse('Aug 25th, 2008',    start), (target, 1)))
+        self.assertTrue(_compareResults(self.cal.parse('Aug. 25th, 2008',   start), (target, 1)))
         self.assertTrue(_compareResults(self.cal.parse('August 25th 2008',  start), (target, 1)))
         self.assertTrue(_compareResults(self.cal.parse('Aug 25th 2008',     start), (target, 1)))
+        self.assertTrue(_compareResults(self.cal.parse('Aug. 25th 2008',    start), (target, 1)))
 
 
     def testSpecialTimes(self):


### PR DESCRIPTION
Tests were breaking using "Aug. 25" instead of "Aug 25". This fixes
that by using a regex to strip out this kind of period usage.
