### PR TITLE
Setup default logging for a library as per recommended practice

### DIFF
--- a/parsedatetime/__init__.py
+++ b/parsedatetime/__init__.py
@@ -25,14 +25,19 @@ import email.utils
 
 from . import pdt_locales
 
+# as a library, do *not* setup logging
+# see http://docs.python.org/2/howto/logging.html#configuring-logging-for-a-library
+# Set default logging handler to avoid "No handler found" warnings.
+import logging
+try:  # Python 2.7+
+    from logging import NullHandler
+except ImportError:
+    class NullHandler(logging.Handler):
+        def emit(self, record):
+            pass
 
-log = logging.getLogger()
-echoHandler   = logging.StreamHandler()
-echoFormatter = logging.Formatter('%(levelname)-8s %(message)s')
-log.addHandler(echoHandler)
-# log.addHandler(logging.NullHandler())
-
-log.setLevel(logging.DEBUG)
+log = logging.getLogger(__name__)
+log.addHandler(NullHandler())
 
 pdtLocales = { 'icu':   pdt_locales.pdtLocale_icu,
                'en_US': pdt_locales.pdtLocale_en,

--- a/parsedatetime/tests/__init__.py
+++ b/parsedatetime/tests/__init__.py
@@ -17,4 +17,11 @@ __contributors__ = [ 'Darshana Chhajed',
                      'Michael Lim (lim.ck.michael@gmail.com)',
                      'Bernd Zeimetz (bzed@debian.org)',
                    ]
+import logging
 
+log = logging.getLogger('parsedatetime')
+echoHandler   = logging.StreamHandler()
+echoFormatter = logging.Formatter('%(levelname)-8s %(message)s')
+log.addHandler(echoHandler)
+
+log.setLevel(logging.DEBUG)     


### PR DESCRIPTION
The current logging setup in parsedatetime forces logging to DEBUG for all applications using the library, which is likely not what people want. This change rectifies that by following the recommended practice.
