### PR TITLE
parse("12 months ago") yields a date 1 year in the future!

### DIFF
--- a/parsedatetime/__init__.py
+++ b/parsedatetime/__init__.py
@@ -1,4 +1,3 @@
-
 """
 parsedatetime
 
@@ -1566,6 +1565,7 @@ class Calendar:
             m = m % 12      # get remaining months
 
             if mi < 0:
+                y *= -1                 # otherwise negative mi will give future dates                                
                 mth = mth - m           # sub months from start month
                 if mth < 1:             # cross start-of-year?
                     y   -= 1            #   yes - decrement year


### PR DESCRIPTION
Fix bug parsing negative months (e.g., "12 months ago" - or any value >12 of months in the past).
