### PR TITLE
Update "import" at README.md example

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ Using parsedatetime
 
 The simple example of how to use parsedatetime is:
 
-    import parsedatetime as pdt
+    import parsedatetime.parsedatetime as pdt
 
     cal = pdt.Calendar()
 


### PR DESCRIPTION
Fix example usage to the new "import parsedatetime.parsedatetime" format. Not sure if this new import style is a bug, but the example usage should reflect the current working version nonetheless.
