### PR TITLE
Basic parsing support for spelled-out numbers

### DIFF
--- a/parsedatetime/pdt_locales.py
+++ b/parsedatetime/pdt_locales.py
@@ -35,7 +35,7 @@ class pdtLocale_base(object):
                     'dateFormats', 'dateSep', 'dayOffsets', 'dp_order', 
                     'localeID', 'meridian', 'Modifiers', 're_sources', 're_values', 
                     'shortMonths', 'shortWeekdays', 'timeFormats', 'timeSep', 'units', 
-                    'uses24', 'usesMeridian' ]
+                    'uses24', 'usesMeridian', 'numbers' ]
 
     def __init__(self):
         self.localeID      = None   # don't use a unicode string
@@ -78,6 +78,15 @@ class pdtLocale_base(object):
                              }
 
         self.dp_order = [ 'm', 'd', 'y' ]
+
+        # Used to parse expressions like "in 5 hours"
+        self.numbers = { 'zero': 0, 'one': 1, 'two': 2, 'three': 3, 'four': 4,
+                         'five': 5, 'six': 6, 'seven': 7, 'eight': 8, 'nine': 9,
+                         'ten': 10, 'eleven': 11, 'twelve': 12, 'thirtheen': 13,
+                         'fourteen': 14, 'fifteen': 15, 'sixteen': 16,
+                         'seventeen': 17, 'eighteen': 18, 'nineteen': 19,
+                         'twenty': 20 }
+
 
           # this will be added to re_values later
         self.units = { 'seconds': [ 'second', 'seconds', 'sec', 's' ],
@@ -153,6 +162,10 @@ class pdtLocale_icu(pdtLocale_base):
             self.icu = pyicu.Locale(localeID)
 
         if self.icu is not None:
+            # grab spelled out format of all numbers from 0 to 100
+            rbnf = pyicu.RuleBasedNumberFormat(pyicu.URBNFRuleSetTag.SPELLOUT, self.icu)
+            self.numbers = dict([(rbnf.format(i), i) for i in xrange(0, 100)])
+
             self.symbols = pyicu.DateFormatSymbols(self.icu)
 
               # grab ICU list of weekdays, skipping first entry which

--- a/parsedatetime/tests/TestSimpleOffsets.py
+++ b/parsedatetime/tests/TestSimpleOffsets.py
@@ -38,10 +38,16 @@ class test(unittest.TestCase):
         self.assertTrue(_compareResults(self.cal.parse('5m from now',        start), (target, 2)))
         self.assertTrue(_compareResults(self.cal.parse('in 5 minutes',       start), (target, 2)))
         self.assertTrue(_compareResults(self.cal.parse('in 5 min',           start), (target, 2)))
-        self.assertTrue(_compareResults(self.cal.parse('5 min from now',     start), (target, 2)))
         self.assertTrue(_compareResults(self.cal.parse('5 minutes',          start), (target, 2)))
         self.assertTrue(_compareResults(self.cal.parse('5 min',              start), (target, 2)))
         self.assertTrue(_compareResults(self.cal.parse('5m',                 start), (target, 2)))
+
+        self.assertTrue(_compareResults(self.cal.parse('five minutes from now', start), (target, 2)))
+        self.assertTrue(_compareResults(self.cal.parse('five min from now',     start), (target, 2)))
+        self.assertTrue(_compareResults(self.cal.parse('in five minutes',       start), (target, 2)))
+        self.assertTrue(_compareResults(self.cal.parse('in five min',           start), (target, 2)))
+        self.assertTrue(_compareResults(self.cal.parse('five minutes',          start), (target, 2)))
+        self.assertTrue(_compareResults(self.cal.parse('five min',              start), (target, 2)))
 
     def testMinutesBeforeNow(self):
         s = datetime.datetime.now()
@@ -54,33 +60,8 @@ class test(unittest.TestCase):
         self.assertTrue(_compareResults(self.cal.parse('5 min before now',     start), (target, 2)))
         self.assertTrue(_compareResults(self.cal.parse('5m before now',        start), (target, 2)))
 
-    def testHoursFromNow(self):
-        s = datetime.datetime.now()
-        t = s + datetime.timedelta(hours=5)
-
-        start  = s.timetuple()
-        target = t.timetuple()
-
-        self.assertTrue(_compareResults(self.cal.parse('5 hours from now', start), (target, 2)))
-        self.assertTrue(_compareResults(self.cal.parse('5 hour from now',  start), (target, 2)))
-        self.assertTrue(_compareResults(self.cal.parse('5 hr from now',    start), (target, 2)))
-        self.assertTrue(_compareResults(self.cal.parse('in 5 hours',       start), (target, 2)))
-        self.assertTrue(_compareResults(self.cal.parse('in 5 hour',        start), (target, 2)))
-        self.assertTrue(_compareResults(self.cal.parse('5 hr from now',    start), (target, 2)))
-        self.assertTrue(_compareResults(self.cal.parse('5 hours',          start), (target, 2)))
-        self.assertTrue(_compareResults(self.cal.parse('5 hr',             start), (target, 2)))
-        self.assertTrue(_compareResults(self.cal.parse('5h',               start), (target, 2)))
-
-    def testHoursBeforeNow(self):
-        s = datetime.datetime.now()
-        t = s + datetime.timedelta(hours=-5)
-
-        start  = s.timetuple()
-        target = t.timetuple()
-
-        self.assertTrue(_compareResults(self.cal.parse('5 hours before now', start), (target, 2)))
-        self.assertTrue(_compareResults(self.cal.parse('5 hr before now',    start), (target, 2)))
-        self.assertTrue(_compareResults(self.cal.parse('5h before now',      start), (target, 2)))
+        self.assertTrue(_compareResults(self.cal.parse('five minutes before now', start), (target, 2)))
+        self.assertTrue(_compareResults(self.cal.parse('five min before now',     start), (target, 2)))
 
     def testWeekFromNow(self):
         s = datetime.datetime.now()
@@ -89,11 +70,15 @@ class test(unittest.TestCase):
         start  = s.timetuple()
         target = t.timetuple()
 
-        self.assertTrue(_compareResults(self.cal.parse('in 1 week',       start), (target, 1)))
-        self.assertTrue(_compareResults(self.cal.parse('1 week from now', start), (target, 1)))
-        self.assertTrue(_compareResults(self.cal.parse('in 7 days',       start), (target, 1)))
-        self.assertTrue(_compareResults(self.cal.parse('7 days from now', start), (target, 1)))
-        #self.assertTrue(_compareResults(self.cal.parse('next week',       start), (target, 1)))
+        self.assertTrue(_compareResults(self.cal.parse('in 1 week',           start), (target, 1)))
+        self.assertTrue(_compareResults(self.cal.parse('1 week from now',     start), (target, 1)))
+        self.assertTrue(_compareResults(self.cal.parse('in one week',         start), (target, 1)))
+        self.assertTrue(_compareResults(self.cal.parse('one week from now',   start), (target, 1)))
+        self.assertTrue(_compareResults(self.cal.parse('in 7 days',           start), (target, 1)))
+        self.assertTrue(_compareResults(self.cal.parse('7 days from now',     start), (target, 1)))
+        self.assertTrue(_compareResults(self.cal.parse('in seven days',       start), (target, 1)))
+        self.assertTrue(_compareResults(self.cal.parse('seven days from now', start), (target, 1)))
+        #self.assertTrue(_compareResults(self.cal.parse('next week',           start), (target, 1)))
 
     def testWeekBeforeNow(self):
         s = datetime.datetime.now()
@@ -102,9 +87,11 @@ class test(unittest.TestCase):
         start  = s.timetuple()
         target = t.timetuple()
 
-        self.assertTrue(_compareResults(self.cal.parse('1 week before now', start), (target, 0)))
-        self.assertTrue(_compareResults(self.cal.parse('7 days before now', start), (target, 0)))
-        #self.assertTrue(_compareResults(self.cal.parse('last week',         start), (target, 0)))
+        self.assertTrue(_compareResults(self.cal.parse('1 week before now',     start), (target, 0)))
+        self.assertTrue(_compareResults(self.cal.parse('one week before now',   start), (target, 0)))
+        self.assertTrue(_compareResults(self.cal.parse('7 days before now',     start), (target, 0)))
+        self.assertTrue(_compareResults(self.cal.parse('seven days before now', start), (target, 0)))
+        #self.assertTrue(_compareResults(self.cal.parse('last week',             start), (target, 0)))
 
     def testSpecials(self):
         s = datetime.datetime.now()

--- a/parsedatetime/tests/TestSimpleOffsetsHours.py
+++ b/parsedatetime/tests/TestSimpleOffsetsHours.py
@@ -37,10 +37,17 @@ class test(unittest.TestCase):
         self.assertTrue(_compareResults(self.cal.parse('5 hr from now',    start), (target, 2)))
         self.assertTrue(_compareResults(self.cal.parse('in 5 hours',       start), (target, 2)))
         self.assertTrue(_compareResults(self.cal.parse('in 5 hour',        start), (target, 2)))
-        self.assertTrue(_compareResults(self.cal.parse('5 hr from now',    start), (target, 2)))
         self.assertTrue(_compareResults(self.cal.parse('5 hours',          start), (target, 2)))
         self.assertTrue(_compareResults(self.cal.parse('5 hr',             start), (target, 2)))
         self.assertTrue(_compareResults(self.cal.parse('5h',               start), (target, 2)))
+
+        self.assertTrue(_compareResults(self.cal.parse('five hours from now', start), (target, 2)))
+        self.assertTrue(_compareResults(self.cal.parse('five hour from now',  start), (target, 2)))
+        self.assertTrue(_compareResults(self.cal.parse('five hr from now',    start), (target, 2)))
+        self.assertTrue(_compareResults(self.cal.parse('in five hours',       start), (target, 2)))
+        self.assertTrue(_compareResults(self.cal.parse('in five hour',        start), (target, 2)))
+        self.assertTrue(_compareResults(self.cal.parse('five hours',          start), (target, 2)))
+        self.assertTrue(_compareResults(self.cal.parse('five hr',             start), (target, 2)))
 
     def testHoursBeforeNow(self):
         s = datetime.datetime.now()
@@ -52,6 +59,9 @@ class test(unittest.TestCase):
         self.assertTrue(_compareResults(self.cal.parse('5 hours before now', start), (target, 2)))
         self.assertTrue(_compareResults(self.cal.parse('5 hr before now',    start), (target, 2)))
         self.assertTrue(_compareResults(self.cal.parse('5h before now',      start), (target, 2)))
+
+        self.assertTrue(_compareResults(self.cal.parse('five hours before now', start), (target, 2)))
+        self.assertTrue(_compareResults(self.cal.parse('five hr before now',    start), (target, 2)))
 
 
 if __name__ == "__main__":

--- a/parsedatetime/tests/TestSimpleOffsetsNoon.py
+++ b/parsedatetime/tests/TestSimpleOffsetsNoon.py
@@ -34,6 +34,7 @@ class test(unittest.TestCase):
         target = t.timetuple()
 
         self.assertTrue(_compareResults(self.cal.parse('5 hours after 12pm',     start), (target, 2)))
+        self.assertTrue(_compareResults(self.cal.parse('five hours after 12pm',  start), (target, 2)))
         #self.assertTrue(_compareResults(self.cal.parse('5 hours after 12 pm',    start), (target, 2)))
         #self.assertTrue(_compareResults(self.cal.parse('5 hours after 12:00pm',  start), (target, 2)))
         #self.assertTrue(_compareResults(self.cal.parse('5 hours after 12:00 pm', start), (target, 2)))
@@ -49,6 +50,7 @@ class test(unittest.TestCase):
 
         #self.assertTrue(_compareResults(self.cal.parse('5 hours before noon',     start), (target, 2)))
         self.assertTrue(_compareResults(self.cal.parse('5 hours before 12pm',     start), (target, 2)))
+        self.assertTrue(_compareResults(self.cal.parse('five hours before 12pm',  start), (target, 2)))
         #self.assertTrue(_compareResults(self.cal.parse('5 hours before 12 pm',    start), (target, 2)))
         #self.assertTrue(_compareResults(self.cal.parse('5 hours before 12:00pm',  start), (target, 2)))
         #self.assertTrue(_compareResults(self.cal.parse('5 hours before 12:00 pm', start), (target, 2)))


### PR DESCRIPTION
Add support for parsing spelled-out numbers in expressions like "in five hours". By default, only the numbers 0 till 20 are recognized, but support is extended up to 100 when icu is available.

Unfortunately I didn't read your implementation notes until I finished this implementation, so it's a bit different (less advanced) from what you proposed there. I understand if you don't want to merge half an implementation, but I think it's a nice start. 
