### PR TITLE
fix import error on itertools.imap with Python 3

### DIFF
--- a/parsedatetime/__init__.py
+++ b/parsedatetime/__init__.py
@@ -22,7 +22,11 @@ import calendar
 import logging
 import email.utils
 
-from itertools import imap, chain
+try:
+    from itertools import imap
+except ImportError:
+    imap = map
+from itertools import chain
 
 from . import pdt_locales
 


### PR DESCRIPTION
`itertools` in Python 3 doesn't have `imap` since `map` does just like that.
