### PR TITLE
Fix support for 'now' when no modifiers are present

### DIFF
--- a/parsedatetime/__init__.py
+++ b/parsedatetime/__init__.py
@@ -900,7 +900,7 @@ class Calendar:
 
         if not flag:
             m = self.ptc.CRE_TIME.match(unit)
-            if m is not None:
+            if m is not None or unit in self.ptc.re_values['now']:
                 log.debug('CRE_TIME matched')
                 self.modifierFlag = False
                 (yr, mth, dy, hr, mn, sec, wd, yd, isdst), _ = self.parse(unit)
@@ -1492,10 +1492,10 @@ class Calendar:
             if parseStr == '':
                 # Natural language time strings
                 m = self.ptc.CRE_TIME.search(s)
-                if m is not None:
+                if m is not None or s in self.ptc.re_values['now']:
                     self.timeStrFlag = True
                     self.timeFlag    = 2
-                    if (m.group('time') != s):
+                    if (m and m.group('time') != s):
                         # capture remaining string
                         parseStr = m.group('time')
                         chunk1   = s[:m.start('time')]
@@ -2122,7 +2122,7 @@ class Constants(object):
             lmodifiers = []
             lmodifiers2 = []
             for s in self.locale.Modifiers:
-                if self.locale.Modifiers[s] < 0 or s == 'after':
+                if self.locale.Modifiers[s] < 0 or s in ['after', 'from']:
                     lmodifiers2.append(s)
                 elif self.locale.Modifiers[s] > 0:
                     lmodifiers.append(s)

--- a/parsedatetime/tests/TestSimpleOffsets.py
+++ b/parsedatetime/tests/TestSimpleOffsets.py
@@ -26,6 +26,14 @@ class test(unittest.TestCase):
         self.cal = pdt.Calendar()
         self.yr, self.mth, self.dy, self.hr, self.mn, self.sec, self.wd, self.yd, self.isdst = time.localtime()
 
+    def testNow(self):
+        s = datetime.datetime.now()
+
+        start = s.timetuple()
+        target = s.timetuple()
+
+        self.assertTrue(_compareResults(self.cal.parse('now', start), (target, 2)))
+
     def testMinutesFromNow(self):
         s = datetime.datetime.now()
         t = s + datetime.timedelta(minutes=5)
@@ -87,11 +95,11 @@ class test(unittest.TestCase):
         start  = s.timetuple()
         target = t.timetuple()
 
-        self.assertTrue(_compareResults(self.cal.parse('1 week before now',     start), (target, 0)))
-        self.assertTrue(_compareResults(self.cal.parse('one week before now',   start), (target, 0)))
-        self.assertTrue(_compareResults(self.cal.parse('7 days before now',     start), (target, 0)))
-        self.assertTrue(_compareResults(self.cal.parse('seven days before now', start), (target, 0)))
-        #self.assertTrue(_compareResults(self.cal.parse('last week',             start), (target, 0)))
+        self.assertTrue(_compareResults(self.cal.parse('1 week before now',     start), (target, 1)))
+        self.assertTrue(_compareResults(self.cal.parse('one week before now',   start), (target, 1)))
+        self.assertTrue(_compareResults(self.cal.parse('7 days before now',     start), (target, 1)))
+        self.assertTrue(_compareResults(self.cal.parse('seven days before now', start), (target, 1)))
+        #self.assertTrue(_compareResults(self.cal.parse('last week',              tart), (target, 1)))
 
     def testSpecials(self):
         s = datetime.datetime.now()


### PR DESCRIPTION
This patch adds support to use 'now' without modifiers to retrieve current time. As a side effect, it also gets sentences like '3 hours before now' to properly set return code.
