### PR TITLE
corrected misspelling of 'thirteen'

### DIFF
--- a/parsedatetime/pdt_locales.py
+++ b/parsedatetime/pdt_locales.py
@@ -82,7 +82,7 @@ class pdtLocale_base(object):
         # Used to parse expressions like "in 5 hours"
         self.numbers = { 'zero': 0, 'one': 1, 'two': 2, 'three': 3, 'four': 4,
                          'five': 5, 'six': 6, 'seven': 7, 'eight': 8, 'nine': 9,
-                         'ten': 10, 'eleven': 11, 'twelve': 12, 'thirtheen': 13,
+                         'ten': 10, 'eleven': 11, 'twelve': 12, 'thirteen': 13,
                          'fourteen': 14, 'fifteen': 15, 'sixteen': 16,
                          'seventeen': 17, 'eighteen': 18, 'nineteen': 19,
                          'twenty': 20 }


### PR DESCRIPTION
Previously spelled "thirtheen", corrected to "thirteen".
