### PR TITLE
fix `KeyError: 'ao\xfbt'` in testDates

### DIFF
--- a/parsedatetime/tests/TestFrenchLocale.py
+++ b/parsedatetime/tests/TestFrenchLocale.py
@@ -4,7 +4,7 @@ Test parsing of simple date and times using the French locale
 
 Note: requires PyICU
 """
-
+from __future__ import unicode_literals
 import unittest, time, datetime
 import parsedatetime as pdt
 


### PR DESCRIPTION
`'ao\xfbt'` is a bytestring on Python 2. The test works on Python 3 where it is a Unicode string.

```
$ python run_tests.py parsedatetime
......................................../parsedatetime/__init__.py:467: UnicodeWarning: Unicode equal comparison failed to convert both arguments to Unicode - interpreting them as being unequal
  mth = self.ptc.MonthOffsets[mth]
E.........
======================================================================
ERROR: testDates (parsedatetime.tests.TestFrenchLocale.test)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "./parsedatetime/tests/TestFrenchLocale.py", line 63, in testDates
    self.assertTrue(_compareResults(self.cal.parse('ao\xfbt 25, 2006', start), (target, 1)))
  File "./parsedatetime/__init__.py", line 1719, in parse
    totalTime = self._evalString(parseStr, totalTime)
  File "./parsedatetime/__init__.py", line 1181, in _evalString
    sourceTime       = self.parseDateText(s, sourceTime)
  File "./parsedatetime/__init__.py", line 467, in parseDateText
    mth = self.ptc.MonthOffsets[mth]
KeyError: 'ao\xfbt'

----------------------------------------------------------------------
Ran 49 tests in 0.256s

FAILED (errors=1)
```
