### PR TITLE
_evalString should use sourceTime as 'now' if set

### DIFF
--- a/parsedatetime/__init__.py
+++ b/parsedatetime/__init__.py
@@ -1079,7 +1079,7 @@ class Calendar:
                  if not parsed
         """
         s   = datetimeString.strip()
-        now = time.localtime()
+        now = sourceTime or time.localtime()
 
         log.debug('_evalString(%s, %s)' % (datetimeString, sourceTime))
 


### PR DESCRIPTION
Hi Mike,

We're using parsedatetime at Disqus, and noticed that the `sourceTime` option doesn't always take effect. For example (my laptop's on PDT):

```
>>> import parsedatetime
>>> from datetime import datetime
>>> c = parsedatetime.Calendar()
>>> c.parse('now', sourceTime=datetime.utcnow())
(time.struct_time(tm_year=2014, tm_mon=10, tm_mday=22, tm_hour=13, tm_min=9, tm_sec=41, tm_wday=2, tm_yday=295, tm_isdst=-1), 2)
```

when I want to get the UTC time (8PM, not 1PM) back.
