### PR TITLE
Bunch of bugfixes (see comments)

### DIFF
--- a/parsedatetime/__init__.py
+++ b/parsedatetime/__init__.py
@@ -966,6 +966,7 @@ class Calendar:
                 # check if the remaining text is parsable and if so,
                 # use it as the base time for the modifier source time
                 t, flag2 = self.parse('%s %s' % (chunk1, unit), sourceTime)
+                chunk1 = ''
 
                 log.debug('flag2 = %s t = %s' % (flag2, t))
 
@@ -994,10 +995,10 @@ class Calendar:
 
         self.modifierFlag = False
 
-        log.debug('returning chunk = "%s" and sourceTime = %s' % (chunk2, sourceTime))
+        log.debug('returning chunk = "%s %s" and sourceTime = %s' %
+                  (chunk1, chunk2, sourceTime))
 
-        #return '%s %s' % (chunk1, chunk2), sourceTime
-        return '%s' % chunk2, sourceTime
+        return '%s %s' % (chunk1, chunk2), sourceTime
 
     def _evalModifier2(self, modifier, chunk1 , chunk2, sourceTime):
         """

--- a/parsedatetime/__init__.py
+++ b/parsedatetime/__init__.py
@@ -2295,7 +2295,7 @@ class Constants(object):
             l = []
             for s in self.locale.re_sources:
                 l.append(s)
-            self.locale.re_values['sources'] = '|'.join(tuple(map(re.escape, l)))
+            self.locale.re_values['sources'] = '|'.join(r'\b' + re.escape(ll) + r'\b' for ll in l)
 
               # build weekday offsets - yes, it assumes the Weekday and shortWeekday
               # lists are in the same order and Mon..Sun (Python style)

--- a/parsedatetime/pdt_locales.py
+++ b/parsedatetime/pdt_locales.py
@@ -125,6 +125,7 @@ class pdtLocale_base(object):
           # to fill in any value to be replace - the current date/time will
           # already have been populated by the method buildSources
         self.re_sources    = { 'noon':      { 'hr': 12, 'mn': 0, 'sec': 0 },
+                               'afternoon': { 'hr': 13, 'mn': 0, 'sec': 0 },
                                'lunch':     { 'hr': 12, 'mn': 0, 'sec': 0 },
                                'morning':   { 'hr':  6, 'mn': 0, 'sec': 0 },
                                'breakfast': { 'hr':  8, 'mn': 0, 'sec': 0 },

--- a/parsedatetime/tests/TestNlp.py
+++ b/parsedatetime/tests/TestNlp.py
@@ -51,7 +51,7 @@ class test(unittest.TestCase):
         #       correct portions of text and their positions are extracted and processed.
         start  = datetime.datetime(2013, 8, 1, 21, 25, 0).timetuple()
         target = ((datetime.datetime(2013, 8, 5, 20, 0), 3, 17, 37, 'At 8PM on August 5th'),
-                  (datetime.datetime(2013, 8, 9, 21, 0), 2, 72, 90, 'next Friday at 9PM'),
+                  (datetime.datetime(2013, 8, 9, 21, 0), 3, 72, 90, 'next Friday at 9PM'),
                   (datetime.datetime(2013, 8, 1, 21, 30, 0), 2, 120, 132, 'in 5 minutes'))
 
         # positive testing

--- a/parsedatetime/tests/TestSimpleDateTimes.py
+++ b/parsedatetime/tests/TestSimpleDateTimes.py
@@ -216,6 +216,10 @@ class test(unittest.TestCase):
 
         self.assertTrue(_compareResults(self.cal.parse('lunch', start), (target, 2)))
 
+        target = datetime.datetime(self.yr, self.mth, self.dy, 13, 0, 0).timetuple()
+
+        self.assertTrue(_compareResults(self.cal.parse('afternoon', start), (target, 2)))
+
         target = datetime.datetime(self.yr, self.mth, self.dy, 18, 0, 0).timetuple()
 
         self.assertTrue(_compareResults(self.cal.parse('evening', start), (target, 2)))

--- a/parsedatetime/tests/TestSimpleOffsets.py
+++ b/parsedatetime/tests/TestSimpleOffsets.py
@@ -80,13 +80,13 @@ class test(unittest.TestCase):
         target = t.timetuple()
 
         self.assertTrue(_compareResults(self.cal.parse('in 1 week',           start), (target, 1)))
-        self.assertTrue(_compareResults(self.cal.parse('1 week from now',     start), (target, 1)))
+        self.assertTrue(_compareResults(self.cal.parse('1 week from now',     start), (target, 3)))
         self.assertTrue(_compareResults(self.cal.parse('in one week',         start), (target, 1)))
-        self.assertTrue(_compareResults(self.cal.parse('one week from now',   start), (target, 1)))
+        self.assertTrue(_compareResults(self.cal.parse('one week from now',   start), (target, 3)))
         self.assertTrue(_compareResults(self.cal.parse('in 7 days',           start), (target, 1)))
-        self.assertTrue(_compareResults(self.cal.parse('7 days from now',     start), (target, 1)))
+        self.assertTrue(_compareResults(self.cal.parse('7 days from now',     start), (target, 3)))
         self.assertTrue(_compareResults(self.cal.parse('in seven days',       start), (target, 1)))
-        self.assertTrue(_compareResults(self.cal.parse('seven days from now', start), (target, 1)))
+        self.assertTrue(_compareResults(self.cal.parse('seven days from now', start), (target, 3)))
         #self.assertTrue(_compareResults(self.cal.parse('next week',           start), (target, 1)))
 
     def testWeekBeforeNow(self):
@@ -96,10 +96,10 @@ class test(unittest.TestCase):
         start  = s.timetuple()
         target = t.timetuple()
 
-        self.assertTrue(_compareResults(self.cal.parse('1 week before now',     start), (target, 1)))
-        self.assertTrue(_compareResults(self.cal.parse('one week before now',   start), (target, 1)))
-        self.assertTrue(_compareResults(self.cal.parse('7 days before now',     start), (target, 1)))
-        self.assertTrue(_compareResults(self.cal.parse('seven days before now', start), (target, 1)))
+        self.assertTrue(_compareResults(self.cal.parse('1 week before now',     start), (target, 3)))
+        self.assertTrue(_compareResults(self.cal.parse('one week before now',   start), (target, 3)))
+        self.assertTrue(_compareResults(self.cal.parse('7 days before now',     start), (target, 3)))
+        self.assertTrue(_compareResults(self.cal.parse('seven days before now', start), (target, 3)))
         self.assertTrue(_compareResults(self.cal.parse('1 week ago',            start), (target, 1)))
         #self.assertTrue(_compareResults(self.cal.parse('last week',              tart), (target, 1)))
 


### PR DESCRIPTION
Here I have met a weird bug that a datetime str (flag 3) has been detected as time str (flag 2). Like this:

```python
import parsedatetime as pdt
pdt.Calendar().parse('friday afternoon 3pm')
```

After I enabling the debug level logging:

```
...
2015-05-06 19:32:19,857 DEBUG: parse (bottom) [  after  3pm][noon][  after][ 3pm]
...
```

So the reason is because https://github.com/bear/parsedatetime/blob/master/parsedatetime/__init__.py#L1631-L1643 split word "afternoon" into "after" and "noon". And the remain "after" causes `Calendar._evalModifier2` being called and dropped the existed `dateFlag = 1` (So perhaps there's another bug in `_evalModifier2`).

In this fix I added "afternoon" phrase in "re_sources", and use `\b` to prevent words being split.

I have all tests passed on my machine.