### PR TITLE
Fixes "next week" and similar modifier + unit pairs in nlp()

### DIFF
--- a/parsedatetime/__init__.py
+++ b/parsedatetime/__init__.py
@@ -1814,22 +1814,6 @@ class Calendar:
                     leftmost_match[3] = 0
                     leftmost_match[4] = 'modifier'
 
-            # Units only; must be preceded by a modifier
-            if len(matches) > 0 and matches[-1][3] == 0:
-                m = self.ptc.CRE_UNITS_ONLY.search(inputString[startpos:])
-                # Ensure that any match is immediately proceded by the
-                # modifier. "Next is the word 'month'" should not parse as a
-                # date while "next month" should
-                if m is not None and inputString[startpos:startpos+m.start()].strip() == '':
-                    debug and log.debug('CRE_UNITS_ONLY matched [%s]' % m.group())
-                    if leftmost_match[1] == 0 or \
-                            leftmost_match[0] > m.start() + startpos:
-                        leftmost_match[0] = m.start() + startpos
-                        leftmost_match[1] = m.end() + startpos
-                        leftmost_match[2] = m.group()
-                        leftmost_match[3] = 3
-                        leftmost_match[4] = 'unitsOnly'
-
             # Quantity + Units
             m = self.ptc.CRE_UNITS.search(inputString[startpos:])
             if m is not None:
@@ -1964,6 +1948,22 @@ class Calendar:
                                                     leftmost_match[1]]
                     leftmost_match[3] = 2
                     leftmost_match[4] = 'timeStd'
+
+            # Units only; must be preceded by a modifier
+            if len(matches) > 0 and matches[-1][3] == 0:
+                m = self.ptc.CRE_UNITS_ONLY.search(inputString[startpos:])
+                # Ensure that any match is immediately proceded by the
+                # modifier. "Next is the word 'month'" should not parse as a
+                # date while "next month" should
+                if m is not None and inputString[startpos:startpos+m.start()].strip() == '':
+                    debug and log.debug('CRE_UNITS_ONLY matched [%s]' % m.group())
+                    if leftmost_match[1] == 0 or \
+                            leftmost_match[0] > m.start() + startpos:
+                        leftmost_match[0] = m.start() + startpos
+                        leftmost_match[1] = m.end() + startpos
+                        leftmost_match[2] = m.group()
+                        leftmost_match[3] = 3
+                        leftmost_match[4] = 'unitsOnly'
 
             # set the start position to the end pos of the leftmost match
             startpos = leftmost_match[1]

--- a/parsedatetime/tests/TestNlp.py
+++ b/parsedatetime/tests/TestNlp.py
@@ -52,23 +52,25 @@ class test(unittest.TestCase):
         start  = datetime.datetime(2013, 8, 1, 21, 25, 0).timetuple()
         target = ((datetime.datetime(2013, 8, 5, 20, 0), 3, 17, 37, 'At 8PM on August 5th'),
                   (datetime.datetime(2013, 8, 9, 21, 0), 3, 72, 90, 'next Friday at 9PM'),
-                  (datetime.datetime(2013, 8, 1, 21, 30, 0), 2, 120, 132, 'in 5 minutes'))
+                  (datetime.datetime(2013, 8, 1, 21, 30, 0), 2, 120, 132, 'in 5 minutes'),
+                  (datetime.datetime(2013, 8, 8, 9, 0), 1, 173, 182, 'next week'))
 
         # positive testing
         self.assertTrue(_compareResults(self.cal.nlp("I'm so excited!! At 8PM on August 5th i'm going to fly to Florida"
                                                      ". Then next Friday at 9PM i'm going to Dog n Bone! And in 5 "
-                                                     "minutes I'm going to eat some food!", start), target))
+                                                     "minutes I'm going to eat some food! Talk to you next week.", start), target))
 
         target = datetime.datetime(self.yr, self.mth, self.dy, 17, 0, 0).timetuple()
 
         # negative testing - no matches should return None
-        self.assertTrue(_compareResults(self.cal.nlp("I'm so excited!! So many things that are going to happen!!", start), None))
+        self.assertTrue(_compareResults(self.cal.nlp("Next, I'm so excited!! So many things that are going to happen every week!!", start), None))
 
         # quotes should not interfere with datetime language recognition
         target = self.cal.nlp("I'm so excited!! At '8PM on August 5th' i'm going to fly to Florida"
                                                      ". Then 'next Friday at 9PM' i'm going to Dog n Bone! And in '5 "
-                                                     "minutes' I'm going to eat some food!", start)
+                                                     "minutes' I'm going to eat some food! Talk to you \"next week\"", start)
 
         self.assertTrue(target[0][4] == "At '8PM on August 5th")
         self.assertTrue(target[1][4] == "next Friday at 9PM")
         self.assertTrue(target[2][4] == "in '5 minutes")
+        self.assertTrue(target[3][4] == "next week")


### PR DESCRIPTION
Fixes #87 for which I had previously employed a workaround in my application to pre-process transform *next month* to *in 1 month*. I am submitting this as a pull request in the hope of some feedback or additional test cases. `nlp()` is somewhat under-tested; while I was able to find and fix a few resulting issues there are probably more cases to test. I would like to have a few eyes on this before I merge it in.

#### Adjacency of modifier and unit

It would not be acceptable to pull out standalone units as dates; simply mentioning the word "week" does not imply a specific date. Instead I required that these units be immediately preceded by a modifier, such that *next week* parses as a date but neither *A week is a long time* nor *Next I will rest for a week* parse as dates.

#### Handling of number + unit pairs was not consistent

One detail of the orginal nlp implementation stuck out to me. In the code that processes matches, there is a comment about proximity of terms and making logical combinations of phrases. Inside the loop, only phrases representing a date or time are parsed (excluding the third type, units). Only on the last iteration were units considered (`if date or time or units:` outside the loop vs `if date or time:` inside the loop). 

I added units within the loop, which could be a source of regression errors if there was a specific reason for that decision. I noticed that the test for nlp was passing only because the number + unit phrase *in 5 minutes* coincidentally appeared as the last matched phrase in the test. Move that sentence (*And in 5 minutes I'm going to eat some food!*) to the beginning of the test string and the test fails. 

@geoffreyfloyd, it was a few years ago but do you happen to remember if there was a reason the units were only checked outside the loop in 9401d0d1b6b400710af66fc9dc01d137288cdb3a?

#### Postfix modifiers?

In some locales such as Spanish the modifier *follows* the unit. For example, the English phrase *next month* could be any of the following in Spanish: *el próximo mes*, *el mes que viene*, *el mes siguiente*. I am unsure whether parsedatetime supports such postfix modifiers in `parse()`, but this commit will not support that format.