### PR TITLE
Add "a" and "an" for phrases like "a week from now"

### DIFF
--- a/parsedatetime/__init__.py
+++ b/parsedatetime/__init__.py
@@ -2340,7 +2340,7 @@ class Constants(object):
                               )
                               \b'''.format(**self.locale.re_values)
 
-        self.RE_NUMBER = (r'(\b{numbers}\b|\d+)'
+        self.RE_NUMBER = (r'(\b(?:{numbers})\b|\d+)'
                           .format(**self.locale.re_values))
 
         self.RE_SPECIAL = (r'(?P<special>^[{specials}]+)\s+'

--- a/parsedatetime/__init__.py
+++ b/parsedatetime/__init__.py
@@ -2351,7 +2351,7 @@ class Constants(object):
 
         self.RE_UNITS = r'''\b(?P<qty>
                                 -?
-                                (?:\d+|{numbers})\s*
+                                (?:\d+|(?:{numbers})\b)\s*
                                 (?P<units>{units})
                             )\b'''.format(**self.locale.re_values)
 

--- a/parsedatetime/pdt_locales.py
+++ b/parsedatetime/pdt_locales.py
@@ -139,6 +139,8 @@ class pdtLocale_base(object):
 
         self.small = {'zero': 0,
                       'one': 1,
+                      'a': 1,
+                      'an': 1,
                       'two': 2,
                       'three': 3,
                       'four': 4,

--- a/parsedatetime/pdt_locales.py
+++ b/parsedatetime/pdt_locales.py
@@ -71,10 +71,10 @@ class pdtLocale_base(object):
         self.dp_order = [ 'm', 'd', 'y' ]
 
         # Used to parse expressions like "in 5 hours"
-        self.numbers = { 'zero': 0, 'one': 1, 'two': 2, 'three': 3, 'four': 4,
-                         'five': 5, 'six': 6, 'seven': 7, 'eight': 8, 'nine': 9,
-                         'ten': 10, 'eleven': 11, 'twelve': 12, 'thirteen': 13,
-                         'fourteen': 14, 'fifteen': 15, 'sixteen': 16,
+        self.numbers = { 'zero': 0, 'one': 1, 'a': 1, 'an': 1, 'two': 2, 'three': 3,
+                         'four': 4, 'five': 5, 'six': 6, 'seven': 7, 'eight': 8,
+                         'nine': 9, 'ten': 10, 'eleven': 11, 'twelve': 12,
+                         'thirteen': 13, 'fourteen': 14, 'fifteen': 15, 'sixteen': 16,
                          'seventeen': 17, 'eighteen': 18, 'nineteen': 19,
                          'twenty': 20 }
 

--- a/parsedatetime/pdt_locales.py
+++ b/parsedatetime/pdt_locales.py
@@ -109,7 +109,6 @@ class pdtLocale_base(object):
                            'last':     -1,
                            'next':      1,
                            'previous': -1,
-                           'in a':      2,
                            'end of':    0,
                            'eod':       1,
                            'eom':       1,

--- a/parsedatetime/tests/TestConvertUnitAsWords.py
+++ b/parsedatetime/tests/TestConvertUnitAsWords.py
@@ -12,12 +12,14 @@ class test(unittest.TestCase):
                       ('zero', 0),
                       ('eleven', 11),
                       ('forty two', 42),
+                      ('a hundred', 100),
                       ('four hundred and fifteen', 415),
                       ('twelve thousand twenty', 12020),
                       ('nine hundred and ninety nine', 999),
                       ('three quintillion four billion', 3000000004000000000),
                       ('forty three thousand, nine hundred and ninety nine', 43999),
-                      ('one hundred thirty three billion four hundred thousand three hundred fourteen', 133000400314)
+                      ('one hundred thirty three billion four hundred thousand three hundred fourteen', 133000400314),
+                      ('an octillion', 1000000000000000000000000000)
                       )
 
     def testConversions(self):

--- a/parsedatetime/tests/TestSimpleOffsets.py
+++ b/parsedatetime/tests/TestSimpleOffsets.py
@@ -89,6 +89,8 @@ class test(unittest.TestCase):
         self.assertExpectedResult(self.cal.parse('1 week from now',     start), (target, 3))
         self.assertExpectedResult(self.cal.parse('in one week',         start), (target, 1))
         self.assertExpectedResult(self.cal.parse('one week from now',   start), (target, 3))
+        self.assertExpectedResult(self.cal.parse('in a week',           start), (target, 1))
+        self.assertExpectedResult(self.cal.parse('a week from now',     start), (target, 3))
         self.assertExpectedResult(self.cal.parse('in 7 days',           start), (target, 1))
         self.assertExpectedResult(self.cal.parse('7 days from now',     start), (target, 3))
         self.assertExpectedResult(self.cal.parse('in seven days',       start), (target, 1))
@@ -122,11 +124,15 @@ class test(unittest.TestCase):
                          _tr((target, 3)))
         self.assertEqual(_tr(self.cal.parse('one week before now', start)),
                          _tr((target, 3)))
+        self.assertEqual(_tr(self.cal.parse('a week before now', start)),
+                         _tr((target, 3)))
         self.assertEqual(_tr(self.cal.parse('7 days before now', start)),
                          _tr((target, 3)))
         self.assertEqual(_tr(self.cal.parse('seven days before now', start)),
                          _tr((target, 3)))
         self.assertEqual(_tr(self.cal.parse('1 week ago', start)),
+                         _tr((target, 1)))
+        self.assertEqual(_tr(self.cal.parse('a week ago', start)),
                          _tr((target, 1)))
         self.assertEqual(_tr(self.cal.parse('last week', start), trunc_hours=True),
                          _tr((target, 1), trunc_hours=True))

--- a/parsedatetime/tests/TestSimpleOffsetsHours.py
+++ b/parsedatetime/tests/TestSimpleOffsetsHours.py
@@ -39,6 +39,20 @@ class test(unittest.TestCase):
         self.assertExpectedResult(self.cal.parse('five hours',          start), (target, 2))
         self.assertExpectedResult(self.cal.parse('five hr',             start), (target, 2))
 
+        # Test "an"
+        t = s + datetime.timedelta(hours=1)
+        target = t.timetuple()
+
+        self.assertExpectedResult(self.cal.parse('an hour from now', start), (target, 2))
+        self.assertExpectedResult(self.cal.parse('in an hour', start), (target, 2))
+        self.assertExpectedResult(self.cal.parse('an hour', start), (target, 2))
+        self.assertExpectedResult(self.cal.parse('an hr', start), (target, 2))
+        self.assertExpectedResult(self.cal.parse('an h', start), (target, 2))
+
+        # No match, should require a word boundary
+        self.assertExpectedResult(self.cal.parse('anhour', start), (start, 0))
+        self.assertExpectedResult(self.cal.parse('an hamburger', start), (start, 0))
+
     def testHoursBeforeNow(self):
         s = datetime.datetime.now()
         t = s + datetime.timedelta(hours=-5)
@@ -52,6 +66,14 @@ class test(unittest.TestCase):
 
         self.assertExpectedResult(self.cal.parse('five hours before now', start), (target, 2))
         self.assertExpectedResult(self.cal.parse('five hr before now',    start), (target, 2))
+
+        # Test "an"
+        t = s + datetime.timedelta(hours=-1)
+        target = t.timetuple()
+
+        self.assertExpectedResult(self.cal.parse('an hour before now', start), (target, 2))
+        self.assertExpectedResult(self.cal.parse('an hr before now', start), (target, 2))
+        self.assertExpectedResult(self.cal.parse('an h before now', start), (target, 2))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Basic idea

*1 month* == *one month* == *a month*
*1 hour* == *one hour* == *an hour*

### Not so simple, tons of failing tests

This change uncovered some bugs that otherwise might have gone unnoticed. Much like the single-letter variants of "month" and "year," adding the single letter "a" to represent a number caused a bunch of tests to fail because "a" is a common letter in other words. The worst offenses that I noticed were "11 AM" parsing as if it were written "11PM 1m" and "1 day" parsing as "1d 1y." Other number words like "one" and "nine" as part of larger words could have caused problems but it was probably not very common for conditions to be just right for the parser to pick that up.

All those failing tests were the motivation for 3dc5d0bd35a21d5d4e2a8170b9ef17cc3cb38ddb.

### Solution

Just a few minor word boundary regex tweaks to get things working properly. 

### Regression

I also removed the English modifier "in a" which was set to +2. I think it should have been +1, but maybe there was some case where that didn't make sense? Either way, "in a week" now parses as "in 1 week" rather than "in 2 weeks."

### Feedback needed

Please let me know if you think of any good reasons to *not* add "a" and "an" – phrases that should not be parsed as dates or would not be parsed correctly. At a minimum the regex bugs that became apparent as a result of adding "a" and "an" will be merged in. This implementation is English only, but should work fine for other languages (e.g. *un mes*, *una semana* for Spanish) if anyone would be willing to contribute the proper translations.