### PR TITLE
Avoid parsing numbers within larger strings as if they were times

### DIFF
--- a/parsedatetime/__init__.py
+++ b/parsedatetime/__init__.py
@@ -2365,7 +2365,7 @@ class Constants(object):
                                    {modifiers}
                                )\b'''.format(**self.locale.re_values)
 
-        self.RE_TIMEHMS = r'''
+        self.RE_TIMEHMS = r'''(\s|-|^)
                               (?P<hours>\d\d?)
                               (?P<tsep>{timeseperator}|)
                               (?P<minutes>\d\d)
@@ -2373,9 +2373,9 @@ class Constants(object):
                                   (?P<seconds>\d\d
                                       (?:[\.,]\d+)?
                                   )
-                              )?'''.format(**self.locale.re_values)
+                              )?\b'''.format(**self.locale.re_values)
 
-        self.RE_TIMEHMS2 = r'''
+        self.RE_TIMEHMS2 = r'''(\s|-|^)
                                (?P<hours>\d\d?)
                                (?:
                                    (?P<tsep>{timeseperator}|)
@@ -2401,6 +2401,8 @@ class Constants(object):
         if 'meridian' in self.locale.re_values:
             self.RE_TIMEHMS2 += (r'\s?(?P<meridian>{meridian})\b'
                                  .format(**self.locale.re_values))
+        else:
+            self.RE_TIMEHMS2 += r'\b'
 
         dateSeps = ''.join(re.escape(s) for s in self.locale.dateSep) + '\.'
 

--- a/parsedatetime/__init__.py
+++ b/parsedatetime/__init__.py
@@ -2365,7 +2365,7 @@ class Constants(object):
                                    {modifiers}
                                )\b'''.format(**self.locale.re_values)
 
-        self.RE_TIMEHMS = r'''(\s|-|^)
+        self.RE_TIMEHMS = r'''([\s(\["'-]|^)
                               (?P<hours>\d\d?)
                               (?P<tsep>{timeseperator}|)
                               (?P<minutes>\d\d)
@@ -2375,7 +2375,7 @@ class Constants(object):
                                   )
                               )?\b'''.format(**self.locale.re_values)
 
-        self.RE_TIMEHMS2 = r'''(\s|-|^)
+        self.RE_TIMEHMS2 = r'''([\s(\["'-]|^)
                                (?P<hours>\d\d?)
                                (?:
                                    (?P<tsep>{timeseperator}|)

--- a/parsedatetime/tests/TestNlp.py
+++ b/parsedatetime/tests/TestNlp.py
@@ -64,6 +64,8 @@ class test(unittest.TestCase):
 
         # negative testing - no matches should return None
         self.assertExpectedResult(self.cal.nlp("Next, I'm so excited!! So many things that are going to happen every week!!", start), None)
+        self.assertExpectedResult(self.cal.nlp("$300", start), None)
+        self.assertExpectedResult(self.cal.nlp("300ml", start), None)
 
         # quotes should not interfere with datetime language recognition
         target = self.cal.nlp("I'm so excited!! At '8PM on August 5th' i'm going to fly to Florida"

--- a/parsedatetime/tests/TestSimpleDateTimes.py
+++ b/parsedatetime/tests/TestSimpleDateTimes.py
@@ -63,6 +63,7 @@ class test(unittest.TestCase):
         self.assertExpectedResult(self.cal.parse('11P.M.',        start), (target, 2))
         self.assertExpectedResult(self.cal.parse('11p.m.',        start), (target, 2))
         self.assertExpectedResult(self.cal.parse('11 p.m.',       start), (target, 2))
+        self.assertExpectedResult(self.cal.parse('"11 p.m."',     start), (target, 2))
 
         target = datetime.datetime(self.yr, self.mth, self.dy, 11, 0, 0).timetuple()
 
@@ -80,6 +81,7 @@ class test(unittest.TestCase):
         self.assertExpectedResult(self.cal.parse('11A.M.',        start), (target, 2))
         self.assertExpectedResult(self.cal.parse('11a.m.',        start), (target, 2))
         self.assertExpectedResult(self.cal.parse('11 a.m.',       start), (target, 2))
+        self.assertExpectedResult(self.cal.parse('(11 a.m.)',     start), (target, 2))
 
         target = datetime.datetime(self.yr, self.mth, self.dy, 7, 30, 0).timetuple()
 

--- a/parsedatetime/tests/TestSimpleDateTimes.py
+++ b/parsedatetime/tests/TestSimpleDateTimes.py
@@ -85,7 +85,7 @@ class test(unittest.TestCase):
 
         self.assertExpectedResult(self.cal.parse('730',  start), (target, 2))
         self.assertExpectedResult(self.cal.parse('0730', start), (target, 2))
-        self.assertExpectedResult(self.cal.parse('730am', start), (target, 2))
+        self.assertExpectedResult(self.cal.parse('0730am', start), (target, 2))
 
         target = datetime.datetime(self.yr, self.mth, self.dy, 17, 30, 0).timetuple()
 

--- a/parsedatetime/tests/TestSimpleDateTimes.py
+++ b/parsedatetime/tests/TestSimpleDateTimes.py
@@ -85,11 +85,16 @@ class test(unittest.TestCase):
 
         self.assertExpectedResult(self.cal.parse('730',  start), (target, 2))
         self.assertExpectedResult(self.cal.parse('0730', start), (target, 2))
+        self.assertExpectedResult(self.cal.parse('730am', start), (target, 2))
 
         target = datetime.datetime(self.yr, self.mth, self.dy, 17, 30, 0).timetuple()
 
         self.assertExpectedResult(self.cal.parse('1730',   start), (target, 2))
         self.assertExpectedResult(self.cal.parse('173000', start), (target, 2))
+
+        # Should not parse as a time due to prefix
+        self.assertExpectedResult(self.cal.parse('$300', start), (start, 0))
+        self.assertExpectedResult(self.cal.parse('300ml', start), (start, 0))
 
     def testDates(self):
         start  = datetime.datetime(self.yr, self.mth, self.dy, self.hr, self.mn, self.sec).timetuple()


### PR DESCRIPTION
For example, neither "$300" nor "300ml" are intended to be "3:00" but "300" and "300am" are fine. The time must be preceded by a space or hyphen (the hyphen is to allow *300-400* style ranges) or appear at the beginning of the string. The time (or time + meridian for AM/PM locales) must be followed by a word boundary.

I opted for `(\s|-|^)` here since, especially considering currencies, many different symbols can precede a number and most will be treated as a word boundary. `\b` would not have fixed the *$300* case. 

This is another one where I'm not sure if all cases are covered but the tests pass and it seems in general to be an improvement. 

I did not make any changes to `evalRanges` via `RE_RTIMEHMS` and `RE_RTIMEHMS2` which look like they may still have word boundary issues. Both `(\s?|^)` (which due to the `?` can match anything) and the lack of `\b` are a bit concerning. For completion since this version is somewhat focused on word boundary fixes we should probably fix those as well.

Otherwise, I think this wraps up my work for this version. Will post a few ideas for the future but I'm not quite ready to get into some of the other parsedatetime-related issues that have come up in my project.