### PR TITLE
Prevented datetime module raising OverflowError when year reached 10000

### DIFF
--- a/parsedatetime/tests/TestErrors.py
+++ b/parsedatetime/tests/TestErrors.py
@@ -49,6 +49,10 @@ class test(unittest.TestCase):
         # ensure short weekday names do not cause false positives at the end of a word - th (thursday)
         self.assertExpectedResult(self.cal.parse('month', start), (start, 0))
         self.assertExpectedErrorFlag(self.cal.parse('30/030/01/071/07', start), (start, 0))
+        # overflow due to Python's datetime
+        self.assertExpectedResult(self.cal.parse('12345 y', start), (start, 0))
+        self.assertExpectedResult(self.cal.parse('654321 w', start), (start, 0))
+        self.assertExpectedResult(self.cal.parse('3700000 d', start), (start, 0))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
`parsedatetime` failed when parsing strings like "548548 W". Actually it should not be treated as a date...

The reason it failed is because python's `datetime` module only accept year larger than 0 or smaller than 9999.

This fix just ignores the OverflowError when it happened and then returns the original datetime.

Tests has been added.