### PR TITLE
Thread-safe context & accuracy flag

### DIFF
--- a/parsedatetime/__init__.py
+++ b/parsedatetime/__init__.py
@@ -23,7 +23,7 @@ Parse human-readable date/time text.
 
 Requires Python 2.6 or later
 """
-from __future__ import with_statement
+from __future__ import with_statement, absolute_import
 
 __author__ = 'Mike Taylor (bear@bear.im)'
 __copyright__ = 'Copyright (c) 2004 Mike Taylor'
@@ -35,12 +35,14 @@ __contributors__ = ['Darshana Chhajed',
 
 import re
 import time
+import warnings
 import datetime
 import calendar
 import contextlib
 import email.utils
 
 from .context import pdtContext, pdtContextStack
+from .warns import pdt20DeprecationWarning
 
 try:
     from itertools import imap
@@ -277,6 +279,12 @@ class Calendar(object):
             self.ptc = constants
 
         self.version = version
+        if version == VERSION_FLAG_STYLE:
+            warnings.warn(
+                'Flag style will be deprecated in parsedatetime 2.0. '
+                'Instead use the context style by instantiating `Calendar()` '
+                'with argument `version=parsedatetime.VERSION_CONTEXT_STYLE`.',
+                pdt20DeprecationWarning)
         self._ctxStack = pdtContextStack()
 
     @contextlib.contextmanager
@@ -2572,7 +2580,8 @@ class Constants(object):
             self.RE_TIMEHMS2 += r'\b'
 
         # Always support common . and - separators
-        dateSeps = ''.join(re.escape(s) for s in self.locale.dateSep + ['-', '.'])
+        dateSeps = ''.join(re.escape(s)
+                           for s in self.locale.dateSep + ['-', '.'])
 
         self.RE_DATE = r'''([\s(\["'-]|^)
                            (?P<date>

--- a/parsedatetime/__init__.py
+++ b/parsedatetime/__init__.py
@@ -142,6 +142,8 @@ def _extract_time(m):
 
 
 def _pop_time_accuracy(m, ctx):
+    if not m:
+        return
     if m.group('hours'):
         ctx.updateAccuracy(ctx.ACU_HOUR)
     if m.group('minutes'):

--- a/parsedatetime/context.py
+++ b/parsedatetime/context.py
@@ -1,4 +1,10 @@
 # -*- coding: utf-8 -*-
+"""
+parsedatetime/context.py
+
+Context related classes
+
+"""
 
 from threading import local
 

--- a/parsedatetime/context.py
+++ b/parsedatetime/context.py
@@ -1,0 +1,57 @@
+# -*- coding: utf-8 -*-
+
+from threading import local
+
+
+class pdtContextStack(object):
+
+    def __init__(self):
+        self.__local = local()
+        self.__local.stack = []
+
+    def push(self, ctx):
+        self.__local.stack.append(ctx)
+
+    def pop(self):
+        try:
+            return self.__local.stack.pop()
+        except IndexError:
+            return None
+
+    def last(self):
+        try:
+            return self.__local.stack[-1]
+        except IndexError:
+            raise RuntimeError('context stack is empty')
+
+    def isEmpty(self):
+        return not self.__local.stack
+
+
+class pdtContext(object):
+
+    __slots__ = ('hasTime', 'hasDate')
+
+    def __init__(self, hasTime=False, hasDate=False):
+        self.hasTime = hasTime
+        self.hasDate = hasDate
+
+    def update(self, context):
+        self.hasTime = self.hasTime or context.hasTime
+        self.hasDate = self.hasDate or context.hasDate
+
+    @property
+    def dateTimeFlag(self):
+        return int(self.hasDate and 1) | int(self.hasTime and 2)
+
+    @property
+    def hasDateOrTime(self):
+        return self.hasDate or self.hasTime
+
+    def __repr__(self):
+        return ('pdtContext(hasTime=%s, hasDate=%s)' %
+                (self.hasTime, self.hasDate))
+
+    def __eq__(self, ctx):
+        return (self.hasTime == ctx.hasTime and
+                self.hasDate == ctx.hasDate)

--- a/parsedatetime/context.py
+++ b/parsedatetime/context.py
@@ -4,6 +4,11 @@ from threading import local
 
 
 class pdtContextStack(object):
+    """
+    A thread-safe stack to store context(s)
+
+    Internally used by L{Calendar} object
+    """
 
     def __init__(self):
         self.__local = local()
@@ -29,29 +34,143 @@ class pdtContextStack(object):
 
 
 class pdtContext(object):
+    """
+    Context contains accuracy flag detected by L{Calendar.parse()}
 
-    __slots__ = ('hasTime', 'hasDate')
+    Accuracy flag uses bitwise-OR operation and is combined by:
 
-    def __init__(self, hasTime=False, hasDate=False):
-        self.hasTime = hasTime
-        self.hasDate = hasDate
+        ACU_YEAR - "next year", "2014"
+        ACU_MONTH - "March", "July 2014"
+        ACU_WEEK - "last week", "next 3 weeks"
+        ACU_DAY - "tomorrow", "July 4th 2014"
+        ACU_HALFDAY - "morning", "tonight"
+        ACU_HOUR - "18:00", "next hour"
+        ACU_MIN - "18:32", "next 10 minutes"
+        ACU_SEC - "18:32:55"
+        ACU_NOW - "now"
+
+    """
+
+    __slots__ = ('accuracy', )
+
+    ACU_YEAR = 1
+    ACU_MONTH = 2
+    ACU_WEEK = 4
+    ACU_DAY = 8
+    ACU_HALFDAY = 16
+    ACU_HOUR = 32
+    ACU_MIN = 64
+    ACU_SEC = 128
+    ACU_NOW = 256
+
+    ACU_DATE = ACU_YEAR | ACU_MONTH | ACU_WEEK | ACU_DAY
+    ACU_TIME = ACU_HALFDAY | ACU_HOUR | ACU_MIN | ACU_SEC | ACU_NOW
+
+    _ACCURACY_MAPPING = [
+        (ACU_YEAR, 'year'),
+        (ACU_MONTH, 'month'),
+        (ACU_WEEK, 'week'),
+        (ACU_DAY, 'day'),
+        (ACU_HALFDAY, 'halfday'),
+        (ACU_HOUR, 'hour'),
+        (ACU_MIN, 'min'),
+        (ACU_SEC, 'sec'),
+        (ACU_NOW, 'now')]
+
+    _ACCURACY_REVERSE_MAPPING = {
+        'year': ACU_YEAR,
+        'years': ACU_YEAR,
+        'month': ACU_MONTH,
+        'months': ACU_MONTH,
+        'week': ACU_WEEK,
+        'weeks': ACU_WEEK,
+        'day': ACU_DAY,
+        'days': ACU_DAY,
+        'halfday': ACU_HALFDAY,
+        'morning': ACU_HALFDAY,
+        'afternoon': ACU_HALFDAY,
+        'evening': ACU_HALFDAY,
+        'night': ACU_HALFDAY,
+        'tonight': ACU_HALFDAY,
+        'midnight': ACU_HALFDAY,
+        'hour': ACU_HOUR,
+        'hours': ACU_HOUR,
+        'min': ACU_MIN,
+        'minute': ACU_MIN,
+        'mins': ACU_MIN,
+        'minutes': ACU_MIN,
+        'sec': ACU_SEC,
+        'second': ACU_SEC,
+        'secs': ACU_SEC,
+        'seconds': ACU_SEC,
+        'now': ACU_NOW}
+
+    def __init__(self, accuracy=0):
+        """
+        Default constructor of L{pdtContext} class.
+
+        @type  accuracy: integer
+        @param accuracy: Accuracy flag
+
+        @rtype:  object
+        @return: L{pdtContext} instance
+        """
+        self.accuracy = accuracy
+
+    def updateAccuracy(self, *accuracy):
+        """
+        Updates current accuracy flag
+        """
+        for acc in accuracy:
+            if not isinstance(acc, int):
+                acc = self._ACCURACY_REVERSE_MAPPING[acc]
+            self.accuracy |= acc
 
     def update(self, context):
-        self.hasTime = self.hasTime or context.hasTime
-        self.hasDate = self.hasDate or context.hasDate
+        """
+        Uses another L{pdtContext} instance to update current one
+        """
+        self.updateAccuracy(context.accuracy)
+
+    @property
+    def hasDate(self):
+        """
+        Returns True if current context is accurate to date
+        """
+        return bool(self.accuracy & self.ACU_DATE)
+
+    @property
+    def hasTime(self):
+        """
+        Returns True if current context is accurate to time
+        """
+        return bool(self.accuracy & self.ACU_TIME)
 
     @property
     def dateTimeFlag(self):
+        """
+        Returns the old date/time flag code
+        """
         return int(self.hasDate and 1) | int(self.hasTime and 2)
 
     @property
     def hasDateOrTime(self):
-        return self.hasDate or self.hasTime
+        """
+        Returns True if current context is accurate to date/time
+        """
+        return bool(self.accuracy)
 
     def __repr__(self):
-        return ('pdtContext(hasTime=%s, hasDate=%s)' %
-                (self.hasTime, self.hasDate))
+        accuracy_repr = []
+        for acc, name in self._ACCURACY_MAPPING:
+            if acc & self.accuracy:
+                accuracy_repr.append('pdtContext.ACU_%s' % name.upper())
+        if accuracy_repr:
+            accuracy_repr = 'accuracy=' + ' | '.join(accuracy_repr)
+        else:
+            accuracy_repr = ''
+
+        return 'pdtContext(%s)' % accuracy_repr
 
     def __eq__(self, ctx):
-        return (self.hasTime == ctx.hasTime and
-                self.hasDate == ctx.hasDate)
+        return self.accuracy == ctx.accuracy

--- a/parsedatetime/context.py
+++ b/parsedatetime/context.py
@@ -59,15 +59,15 @@ class pdtContext(object):
 
     __slots__ = ('accuracy', )
 
-    ACU_YEAR = 1
-    ACU_MONTH = 2
-    ACU_WEEK = 4
-    ACU_DAY = 8
-    ACU_HALFDAY = 16
-    ACU_HOUR = 32
-    ACU_MIN = 64
-    ACU_SEC = 128
-    ACU_NOW = 256
+    ACU_YEAR = 2**0
+    ACU_MONTH = 2**1
+    ACU_WEEK = 2**2
+    ACU_DAY = 2**3
+    ACU_HALFDAY = 2**4
+    ACU_HOUR = 2**5
+    ACU_MIN = 2**6
+    ACU_SEC = 2**7
+    ACU_NOW = 2**8
 
     ACU_DATE = ACU_YEAR | ACU_MONTH | ACU_WEEK | ACU_DAY
     ACU_TIME = ACU_HALFDAY | ACU_HOUR | ACU_MIN | ACU_SEC | ACU_NOW

--- a/parsedatetime/pdt_locales.py
+++ b/parsedatetime/pdt_locales.py
@@ -110,6 +110,7 @@ class pdtLocale_base(object):
                            'next':      1,
                            'previous': -1,
                            'end of':    0,
+                           'this':      0,
                            'eod':       1,
                            'eom':       1,
                            'eoy':       1,

--- a/parsedatetime/tests/TestContext.py
+++ b/parsedatetime/tests/TestContext.py
@@ -16,15 +16,30 @@ class test(unittest.TestCase):
         (self.yr, self.mth, self.dy, self.hr, self.mn,
          self.sec, self.wd, self.yd, self.isdst) = time.localtime()
 
-    def test(self):
+    def testContext(self):
         self.assertEqual(self.cal.parse('5 min from now')[1],
-                         pdtContext(hasTime=True, hasDate=False))
+                         pdtContext(pdtContext.ACU_MIN | pdtContext.ACU_NOW))
+        self.assertEqual(self.cal.parse('5 min from now',
+                                        version=pdt.VERSION_FLAG_STYLE)[1], 2)
         self.assertEqual(self.cal.parse('7/11/2015')[1],
-                         pdtContext(hasTime=False, hasDate=True))
+                         pdtContext(pdtContext.ACU_YEAR |
+                                    pdtContext.ACU_MONTH | pdtContext.ACU_DAY))
+        self.assertEqual(self.cal.parse('7/11/2015',
+                                        version=pdt.VERSION_FLAG_STYLE)[1], 1)
         self.assertEqual(self.cal.parse('14/32/2015')[1],
-                         pdtContext(hasTime=False, hasDate=False))
+                         pdtContext(0))
         self.assertEqual(self.cal.parse('25:23')[1],
-                         pdtContext(hasTime=False, hasDate=False))
+                         pdtContext())
+
+    def testSources(self):
+        self.assertEqual(self.cal.parse('afternoon 5pm')[1],
+                         pdtContext(pdtContext.ACU_HALFDAY |
+                                    pdtContext.ACU_HOUR))
+
+        self.assertEqual(self.cal.parse('morning')[1],
+                         pdtContext(pdtContext.ACU_HALFDAY))
+
+        self.assertEqual(self.cal.parse('night', version=1)[1], 2)
 
 
 if __name__ == "__main__":

--- a/parsedatetime/tests/TestContext.py
+++ b/parsedatetime/tests/TestContext.py
@@ -1,0 +1,31 @@
+# -*- coding: utf-8 -*-
+"""
+Test pdtContext
+"""
+
+import time
+import unittest
+import parsedatetime as pdt
+from parsedatetime.context import pdtContext
+
+
+class test(unittest.TestCase):
+
+    def setUp(self):
+        self.cal = pdt.Calendar(version=pdt.VERSION_CONTEXT_STYLE)
+        (self.yr, self.mth, self.dy, self.hr, self.mn,
+         self.sec, self.wd, self.yd, self.isdst) = time.localtime()
+
+    def test(self):
+        self.assertEqual(self.cal.parse('5 min from now')[1],
+                         pdtContext(hasTime=True, hasDate=False))
+        self.assertEqual(self.cal.parse('7/11/2015')[1],
+                         pdtContext(hasTime=False, hasDate=True))
+        self.assertEqual(self.cal.parse('14/32/2015')[1],
+                         pdtContext(hasTime=False, hasDate=False))
+        self.assertEqual(self.cal.parse('25:23')[1],
+                         pdtContext(hasTime=False, hasDate=False))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/parsedatetime/tests/TestPhrases.py
+++ b/parsedatetime/tests/TestPhrases.py
@@ -3,7 +3,9 @@
 Test parsing of strings that are phrases
 """
 
-import unittest, time, datetime
+import time
+import datetime
+import unittest
 import parsedatetime as pdt
 
 class test(unittest.TestCase):
@@ -96,8 +98,8 @@ class test(unittest.TestCase):
         start  = s.timetuple()
         target = t.timetuple()
 
-        self.assertExpectedResult(self.cal.parse('eom',         start), (target, 2))
-        self.assertExpectedResult(self.cal.parse('meeting eom', start), (target, 2))
+        self.assertExpectedResult(self.cal.parse('eom',         start), (target, 1))
+        self.assertExpectedResult(self.cal.parse('meeting eom', start), (target, 1))
 
         s = datetime.datetime.now()
 
@@ -108,8 +110,8 @@ class test(unittest.TestCase):
         start  = s.timetuple()
         target = t.timetuple()
 
-        self.assertExpectedResult(self.cal.parse('eoy',         start), (target, 2))
-        self.assertExpectedResult(self.cal.parse('meeting eoy', start), (target, 2))
+        self.assertExpectedResult(self.cal.parse('eoy',         start), (target, 1))
+        self.assertExpectedResult(self.cal.parse('meeting eoy', start), (target, 1))
 
     def testLastPhrases(self):
         for day in (11, 12, 13, 14, 15, 16, 17):

--- a/parsedatetime/tests/TestStartTimeFromSourceTime.py
+++ b/parsedatetime/tests/TestStartTimeFromSourceTime.py
@@ -4,8 +4,11 @@ Test parsing of strings that are phrases with the
 ptc.StartTimeFromSourceTime flag set to True
 """
 
-import unittest, time, datetime
+import time
+import datetime
+import unittest
 import parsedatetime as pdt
+
 
 class test(unittest.TestCase):
 
@@ -21,9 +24,9 @@ class test(unittest.TestCase):
     def testEndOfPhrases(self):
         s = datetime.datetime.now()
 
-          # find out what month we are currently on
-          # set the day to 1 and then go back a day
-          # to get the end of the current month
+        # find out what month we are currently on
+        # set the day to 1 and then go back a day
+        # to get the end of the current month
         (yr, mth, dy, hr, mn, sec, _, _, _) = s.timetuple()
 
         m    = mth
@@ -38,8 +41,8 @@ class test(unittest.TestCase):
         start  = s.timetuple()
         target = t.timetuple()
 
-        self.assertExpectedResult(self.cal.parse('eom',         start), (target, 2))
-        self.assertExpectedResult(self.cal.parse('meeting eom', start), (target, 2))
+        self.assertExpectedResult(self.cal.parse('eom',         start), (target, 1))
+        self.assertExpectedResult(self.cal.parse('meeting eom', start), (target, 1))
 
         s = datetime.datetime.now()
 
@@ -51,5 +54,5 @@ class test(unittest.TestCase):
         start  = s.timetuple()
         target = t.timetuple()
 
-        self.assertExpectedResult(self.cal.parse('eoy',         start), (target, 2))
-        self.assertExpectedResult(self.cal.parse('meeting eoy', start), (target, 2))
+        self.assertExpectedResult(self.cal.parse('eoy',         start), (target, 1))
+        self.assertExpectedResult(self.cal.parse('meeting eoy', start), (target, 1))

--- a/parsedatetime/warns.py
+++ b/parsedatetime/warns.py
@@ -1,0 +1,26 @@
+# -*- coding: utf-8 -*-
+"""
+parsedatetime/warns.py
+
+All subclasses inherited from `Warning` class
+
+"""
+from __future__ import absolute_import
+
+import warnings
+
+
+class pdtDeprecationWarning(DeprecationWarning):
+    pass
+
+
+class pdtPendingDeprecationWarning(PendingDeprecationWarning):
+    pass
+
+
+class pdt20DeprecationWarning(pdtPendingDeprecationWarning):
+    pass
+
+
+warnings.simplefilter('default', pdtDeprecationWarning)
+warnings.simplefilter('ignore', pdtPendingDeprecationWarning)


### PR DESCRIPTION
This is a refactor of current `parsedatetime` module. I removed all `*Flag` attributes from `Calendar` object and used thread-safe `pdtContext` to replace them. There are two huge methods in `Calendar` class, the `parse()` and `_evalString()`. They have been broke up into several small methods.

Also, this pull request introduced a new system to record if certain datetime string contains year, month, week, day, hour, minute, second, halfday (for example, afternoon or midnight) or "now". With such ability, not only we can know if the string contains date/time, but also the accuracy of date/time it brings with.

Method `parse()` and `parseDT()` are both added a new parameter "version". When `version` equals to 1 which is also the current default value, the methods' second return value is still the old "flag" style 0, 1, 2 or 3.  But if `version` equals to 2, the methods will return a `pdtContext` object, which allows user to inspect the text deeper.