### PR TITLE
Adds yyyy/mm/dd and ISO 8601 yyyy-mm-dd support

### DIFF
--- a/parsedatetime/__init__.py
+++ b/parsedatetime/__init__.py
@@ -425,9 +425,12 @@ class Calendar:
         v = [v1, v2, v3]
         d = {'m': mth, 'd': dy, 'y': yr}
 
+        # yyyy/mm/dd format
+        dp_order = self.ptc.dp_order if v1 <= 31 else ['y', 'm', 'd']
+
         for i in range(0, 3):
             n = v[i]
-            c = self.ptc.dp_order[i]
+            c = dp_order[i]
             if n >= 0:
                 d[c] = n
 
@@ -2425,7 +2428,11 @@ class Constants(object):
         dateSeps = ''.join(re.escape(s) for s in self.locale.dateSep) + '\.'
 
         self.RE_DATE = r'''([\s(\["'-]|^)
-                           (?P<date>\d\d?[{0}]\d\d?(?:[{0}]\d\d(?:\d\d)?)?)
+                           (?P<date>
+                                \d\d?[{0}]\d\d?(?:[{0}]\d\d(?:\d\d)?)?
+                                |
+                                \d{{4}}[{0}]\d\d?[{0}]\d\d?
+                            )
                            \b'''.format(dateSeps)
 
         self.RE_DATE2 = r'[{0}]'.format(dateSeps)

--- a/parsedatetime/__init__.py
+++ b/parsedatetime/__init__.py
@@ -2425,7 +2425,8 @@ class Constants(object):
         else:
             self.RE_TIMEHMS2 += r'\b'
 
-        dateSeps = ''.join(re.escape(s) for s in self.locale.dateSep) + '\.'
+        # Always support common . and - separators
+        dateSeps = ''.join(re.escape(s) for s in self.locale.dateSep + ['-', '.'])
 
         self.RE_DATE = r'''([\s(\["'-]|^)
                            (?P<date>

--- a/parsedatetime/tests/TestSimpleDateTimes.py
+++ b/parsedatetime/tests/TestSimpleDateTimes.py
@@ -104,6 +104,8 @@ class test(unittest.TestCase):
 
         self.assertExpectedResult(self.cal.parse('08/25/2006',      start), (target, 1))
         self.assertExpectedResult(self.cal.parse('08.25.2006',      start), (target, 1))
+        self.assertExpectedResult(self.cal.parse('2006/08/25',      start), (target, 1))
+        self.assertExpectedResult(self.cal.parse('2006/8/25',       start), (target, 1))
         self.assertExpectedResult(self.cal.parse('8/25/06',         start), (target, 1))
         self.assertExpectedResult(self.cal.parse('August 25, 2006', start), (target, 1))
         self.assertExpectedResult(self.cal.parse('Aug 25, 2006',    start), (target, 1))

--- a/parsedatetime/tests/TestSimpleDateTimes.py
+++ b/parsedatetime/tests/TestSimpleDateTimes.py
@@ -106,6 +106,7 @@ class test(unittest.TestCase):
         self.assertExpectedResult(self.cal.parse('08.25.2006',      start), (target, 1))
         self.assertExpectedResult(self.cal.parse('2006/08/25',      start), (target, 1))
         self.assertExpectedResult(self.cal.parse('2006/8/25',       start), (target, 1))
+        self.assertExpectedResult(self.cal.parse('2006-08-25',      start), (target, 1))
         self.assertExpectedResult(self.cal.parse('8/25/06',         start), (target, 1))
         self.assertExpectedResult(self.cal.parse('August 25, 2006', start), (target, 1))
         self.assertExpectedResult(self.cal.parse('Aug 25, 2006',    start), (target, 1))


### PR DESCRIPTION
The yyyy/mm/dd format is the primary or secondary date format in about two dozen countries. Additionally, the international standard yyyy-mm-dd ISO 8601 date format is widely used and worth supporting as it transcends locales and is used often in the government and technical fields.

This pull request adds year-first date support by testing whether the first number is greater than 31 and if so assuming yyyy/mm/dd instead of the locale's date formatting order. The date regex has been modified to allow year-first as an entirely alternate case to xx/xx/yyyy (so that it is not possible to match something like 1234/56/7890 as a date). It is worth noting that according to Wikipedia only one country, Kazakhstan, uses yyyy.dd.mm format, but ICU does not reflect that format.

I did not go into the time component of ISO 8601 dates because while matching the time itself is trivial, I am not sure how to handle the time zone offset. If this looks good enough it will close #107.