### PR TITLE
Add datetime example to readme.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,6 +50,14 @@ An example of how to use parsedatetime::
 
     cal.parse("tomorrow")
 
+To get it to a Python ``datetime`` object::
+
+    from datetime import datetime
+    from time import mktime
+
+    time_struct, parse_status = cal.parse("tomorrow")
+    datetime.fromtimestamp(mktime(time_struct))
+
 More detailed examples can be found in the examples directory.
 
 =============


### PR DESCRIPTION
Fixes: https://github.com/bear/parsedatetime/issues/112

@bear Does this example work in all cases you can imagine?  I tried with `"tomorrow"`, `"4:30 pm"`, and `"2015-08-08"`.  I realized that the second item in the tuple that's returned from `Calendar.parse` changes the type of object that's returned as the first item, but both cases I saw worked fine when passed to `mktime`.