### PR TITLE
bug(date3): rely on comparison of hour and year strings but not strict char position

### DIFF
--- a/parsedatetime/__init__.py
+++ b/parsedatetime/__init__.py
@@ -1427,9 +1427,6 @@ class Calendar(object):
                 # capture remaining string
                 mStart = m.start('date')
                 mEnd = m.end('date')
-                parseStr = m.group('date')
-                chunk1 = s[:mStart]
-                chunk2 = s[mEnd:]
 
                 # we need to check that anything following the parsed
                 # date is a time expression because it is often picked
@@ -1438,21 +1435,23 @@ class Calendar(object):
                 mm = self.ptc.CRE_TIMEHMS2.search(s)
                 # "February 24th 1PM" doesn't get caught
                 # "February 24th 12PM" does
-                if mm is not None and m.group('year') is not None:
+                mYear = m.group('year')
+                if mm is not None and mYear is not None:
                     fTime = True
                 else:
                     # "February 24th 12:00"
                     mm = self.ptc.CRE_TIMEHMS.search(s)
-                    if mm is not None and m.group('year') is None:
+                    if mm is not None and mYear is None:
                         fTime = True
                 if fTime:
-                    n = mm.end('hours') - mm.start('hours')
-                    sEnd = parseStr[-n:]
-                    sStart = mm.group('hours')
+                    hoursStart = mm.start('hours')
 
-                    if sStart == sEnd:
-                        parseStr = parseStr[:mEnd - n].strip()
-                        chunk2 = s[mEnd - n:]
+                    if hoursStart < m.end('year'):
+                        mEnd = hoursStart
+
+                parseStr = s[mStart:mEnd]
+                chunk1 = s[:mStart]
+                chunk2 = s[mEnd:]
 
                 s = '%s %s' % (chunk1, chunk2)
             else:

--- a/tests/TestComplexDateTimes.py
+++ b/tests/TestComplexDateTimes.py
@@ -23,6 +23,49 @@ class test(unittest.TestCase):
         (self.yr, self.mth, self.dy, self.hr,
          self.mn, self.sec, self.wd, self.yd, self.isdst) = time.localtime()
 
+    def testDate3ConfusedHourAndYear(self):
+        start = datetime.datetime(
+            self.yr, self.mth, self.dy, self.hr, self.mn, self.sec).timetuple()
+        self.assertExpectedResult(
+            self.cal.parse('Aug 05, 2014 4:15 AM'),
+            (datetime.datetime(2014, 8, 5, 4, 15, 0).timetuple(), 3))
+        self.assertExpectedResult(
+            self.cal.parse('Aug 05, 2003 3:15 AM'),
+            (datetime.datetime(2003, 8, 5, 3, 15, 0).timetuple(), 3))
+        self.assertExpectedResult(
+            self.cal.parse('Aug 05, 2003 03:15 AM'),
+            (datetime.datetime(2003, 8, 5, 3, 15, 0).timetuple(), 3))
+        self.assertExpectedResult(
+            self.cal.parse('June 30th 12PM', start),
+            (datetime.datetime(self.yr
+                               if (self.mth < 6 and
+                                   self.dy < 30 and self.hr < 12)
+                               else self.yr + 1,
+                               6, 30, 12, 0, 0).timetuple(), 3))
+        self.assertExpectedResult(
+            self.cal.parse('June 30th 12:00', start),
+            (datetime.datetime(self.yr
+                               if (self.mth < 6 and
+                                   self.dy < 30 and self.hr < 12)
+                               else self.yr + 1,
+                               6, 30, 12, 0, 0).timetuple(), 3))
+        self.assertExpectedResult(
+            self.cal.parse('December 30th 23PM', start),
+            (datetime.datetime(self.yr
+                               if (self.mth < 12 and
+                                   self.dy < 30 and self.hr < 23)
+                               else self.yr + 1,
+                               12, 30, 23, 0, 0).timetuple(), 3))
+        self.assertExpectedResult(
+            self.cal.parse('December 30th 23:02', start),
+            (datetime.datetime(self.yr
+                               if (self.mth < 12 and
+                                   self.dy < 30 and
+                                   self.hr < 23 and
+                                   self.mn < 2)
+                               else self.yr + 1,
+                               12, 30, 23, 2, 0).timetuple(), 3))
+
     def testDates(self):
         start = datetime.datetime(
             self.yr, self.mth, self.dy, self.hr, self.mn, self.sec).timetuple()


### PR DESCRIPTION
Which cause certain strings with format like "MM DD, YYxx xx:SS" parsed incorrectly.

See #137