### PR TITLE
Test failure: eom is correct, but expectation is wrong

### DIFF
--- a/tests/TestStartTimeFromSourceTime.py
+++ b/tests/TestStartTimeFromSourceTime.py
@@ -32,13 +32,12 @@ class test(unittest.TestCase):
         # to get the end of the current month
         (yr, mth, dy, hr, mn, sec, _, _, _) = s.timetuple()
 
-        m = mth
+        s = datetime.datetime(yr, mth, dy, 13, 14, 15)
+
         mth += 1
         if mth > 12:
             mth = 1
             yr += 1
-
-        s = datetime.datetime(yr, m, dy, 13, 14, 15)
         t = datetime.datetime(
             yr, mth, 1, 13, 14, 15) + datetime.timedelta(days=-1)
 


### PR DESCRIPTION
This test fails in december, because the source time of calculation (s)
is in the next year (because it is generated after yr += 1).

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bear/parsedatetime/146)
<!-- Reviewable:end -->
