### PR TITLE
Do not add "-" and "." as universal date separators

### DIFF
--- a/parsedatetime/__init__.py
+++ b/parsedatetime/__init__.py
@@ -2576,19 +2576,18 @@ class Constants(object):
         else:
             self.RE_TIMEHMS2 += r'\b'
 
-        # Always support common . and - separators
-        dateSeps = ''.join(re.escape(s)
-                           for s in self.locale.dateSep + ['-', '.'])
+        dateSeps = re.escape(''.join(self.locale.dateSep))
 
+        # Add - as a date separator only for yyyy-mm-dd format
         self.RE_DATE = r'''([\s(\["'-]|^)
                            (?P<date>
                                 \d\d?[{0}]\d\d?(?:[{0}]\d\d(?:\d\d)?)?
                                 |
-                                \d{{4}}[{0}]\d\d?[{0}]\d\d?
+                                \d{{4}}[{0}-]\d\d?[{0}-]\d\d?
                             )
                            \b'''.format(dateSeps)
 
-        self.RE_DATE2 = r'[{0}]'.format(dateSeps)
+        self.RE_DATE2 = r'[{0}-]'.format(dateSeps)
 
         assert 'dayoffsets' in self.locale.re_values
 

--- a/tests/TestAustralianLocale.py
+++ b/tests/TestAustralianLocale.py
@@ -83,8 +83,6 @@ class test(unittest.TestCase):
         self.assertExpectedResult(
             self.cal.parse('25/08/2006', start), (target, 1))
         self.assertExpectedResult(
-            self.cal.parse('25.08.2006', start), (target, 1))
-        self.assertExpectedResult(
             self.cal.parse('25-8-06', start), (target, 1))
         self.assertExpectedResult(
             self.cal.parse('25/8/06', start), (target, 1))
@@ -98,7 +96,6 @@ class test(unittest.TestCase):
 
         self.assertExpectedResult(self.cal.parse('25-8', start), (target, 1))
         self.assertExpectedResult(self.cal.parse('25/8', start), (target, 1))
-        self.assertExpectedResult(self.cal.parse('25.8', start), (target, 1))
         self.assertExpectedResult(self.cal.parse('25-08', start), (target, 1))
         self.assertExpectedResult(self.cal.parse('25/08', start), (target, 1))
 


### PR DESCRIPTION
In response to #150, the "-" and "." characters are no longer added to the locale date separator list for all of the expressions that make use of the date separators. The "-" character is still used for the yyyy-mm-dd pattern only, which as discussed previously is an international format.

I noticed that "." is a date separator in the base locale so this confusion between decimals and dates will continue to affect most users. That is really a domain issue – if the data you're processing is likely to always contain a date you would want to avoid false negatives, while someone parsing a date out of freeform text would prefer to avoid false positives. Fortunately after this change the '.' separator can be disabled by the developer if necessary. 