### PR TITLE
Fix/day of week offsets

### DIFF
--- a/parsedatetime/__init__.py
+++ b/parsedatetime/__init__.py
@@ -910,6 +910,12 @@ class Calendar(object):
                     sourceTime = sTime
                     ctx.updateAccuracy(ctx.ACU_HALFDAY)
             else:
+                # unless one of these modifiers is being applied to the
+                # day-of-week, we want to start with target as the day
+                # in the current week.
+                if not modifier in ['next', 'last', 'prior', 'previous']:
+                    offset = 0
+
                 wkdy = self.ptc.WeekdayOffsets[wkdy]
                 diff = self._CalculateDOWDelta(
                     wd, wkdy, offset, self.ptc.DOWParseStyle,

--- a/parsedatetime/__init__.py
+++ b/parsedatetime/__init__.py
@@ -913,16 +913,28 @@ class Calendar(object):
                 # unless one of these modifiers is being applied to the
                 # day-of-week, we want to start with target as the day
                 # in the current week.
+                dowOffset = offset
                 if not modifier in ['next', 'last', 'prior', 'previous']:
-                    offset = 0
+                    dowOffset = 0
 
                 wkdy = self.ptc.WeekdayOffsets[wkdy]
                 diff = self._CalculateDOWDelta(
-                    wd, wkdy, offset, self.ptc.DOWParseStyle,
+                    wd, wkdy, dowOffset, self.ptc.DOWParseStyle,
                     self.ptc.CurrentDOWParseStyle)
                 start = datetime.datetime(yr, mth, dy, startHour,
                                           startMinute, startSecond)
                 target = start + datetime.timedelta(days=diff)
+
+                if chunk1 != '':
+                    # consider "one day before thursday": we need to parse chunk1 ("one day")
+                    # and apply according to the offset ("before"), rather than allowing the
+                    # remaining parse step to apply "one day" without the offset direction.
+                    t, subctx = self.parse(chunk1, sourceTime, VERSION_CONTEXT_STYLE)
+                    if subctx.hasDateOrTime:
+                        delta = time.mktime(t) - time.mktime(sourceTime)
+                        target = start + datetime.timedelta(days=diff) + datetime.timedelta(seconds = delta * offset)
+                        chunk1 = ''
+
                 sourceTime = target.timetuple()
             ctx.updateAccuracy(ctx.ACU_DAY)
 

--- a/tests/TestSimpleOffsets.py
+++ b/tests/TestSimpleOffsets.py
@@ -46,7 +46,7 @@ class test(unittest.TestCase):
 
         self.assertExpectedResult(self.cal.parse('now', start), (target, 2))
 
-    def testWeeksFromDayOfWeek(self):
+    def testOffsetFromDayOfWeek(self):
         self.cal.ptc.StartTimeFromSourceTime = True
 
         s = datetime.datetime(2016, 2, 16) # a Tuesday
@@ -62,6 +62,23 @@ class test(unittest.TestCase):
 
         self.assertExpectedResult(
             self.cal.parse('one hour from Thursday', start), (targetPlusOffset, 3))
+
+    def testOffsetBeforeDayOfWeek(self):
+        self.cal.ptc.StartTimeFromSourceTime = True
+
+        s = datetime.datetime(2016, 2, 16) # a Tuesday
+        t = datetime.datetime(2016, 2, 18) # Thursday of the same week
+        tPlusOffset = t + datetime.timedelta(hours=-1)
+
+        start = s.timetuple()
+        target = t.timetuple()
+        targetPlusOffset = tPlusOffset.timetuple()
+
+        self.assertExpectedResult(
+            self.cal.parse('Thursday', start), (target, 1))
+
+        self.assertExpectedResult(
+            self.cal.parse('one hour before Thursday', start), (targetPlusOffset, 3))
 
     def testMinutesFromNow(self):
         s = datetime.datetime.now()

--- a/tests/TestSimpleOffsets.py
+++ b/tests/TestSimpleOffsets.py
@@ -46,6 +46,23 @@ class test(unittest.TestCase):
 
         self.assertExpectedResult(self.cal.parse('now', start), (target, 2))
 
+    def testWeeksFromDayOfWeek(self):
+        self.cal.ptc.StartTimeFromSourceTime = True
+
+        s = datetime.datetime(2016, 2, 16) # a Tuesday
+        t = datetime.datetime(2016, 2, 18) # Thursday of the same week
+        tPlusOffset = t + datetime.timedelta(hours=1)
+
+        start = s.timetuple()
+        target = t.timetuple()
+        targetPlusOffset = tPlusOffset.timetuple()
+
+        self.assertExpectedResult(
+            self.cal.parse('Thursday', start), (target, 1))
+
+        self.assertExpectedResult(
+            self.cal.parse('one hour from Thursday', start), (targetPlusOffset, 3))
+
     def testMinutesFromNow(self):
         s = datetime.datetime.now()
         t = s + datetime.timedelta(minutes=5)


### PR DESCRIPTION
This PR fixes two distinct issues parsing strings with time offsets relative to days of the week.  

The first issue is that the modifier "offset" is being turned into a week offset for the day of week.  This makes sense for parsing some modifiers ('next', 'last', 'prior', 'previous'), but not for others ('from', 'before', 'after').

The second issue is that even with the previous issue fixed, backwards offsets were not applied properly for day-of-week modifiers.  The day of week was resolved properly, but parsing of the remaining chunk was left to the caller and would always offset forward. 

The added test cases demonstrate the issues and the fix, as do the examples below.

Before:

```
>>> datetime.datetime.now()
datetime.datetime(2016, 2, 16, 14, 5, 24, 684154)
>>> cal.parse('Thursday')                 # correct
(time.struct_time(tm_year=2016, tm_mon=2, tm_mday=18, tm_hour=14, tm_min=5, tm_sec=34, tm_wday=3, tm_yday=49, tm_isdst=-1), 1)
>>> cal.parse('one day after Thursday')  # should give 2/19
(time.struct_time(tm_year=2016, tm_mon=2, tm_mday=26, tm_hour=9, tm_min=0, tm_sec=0, tm_wday=4, tm_yday=57, tm_isdst=-1), 1)
>>> cal.parse('one day before Thursday') # should give 2/17
(time.struct_time(tm_year=2016, tm_mon=2, tm_mday=12, tm_hour=9, tm_min=0, tm_sec=0, tm_wday=4, tm_yday=43, tm_isdst=-1), 1)
```


After:

```
>>> datetime.datetime.now()
datetime.datetime(2016, 2, 16, 15, 19, 6, 123021)
>>> cal.parse('Thursday')
(time.struct_time(tm_year=2016, tm_mon=2, tm_mday=18, tm_hour=15, tm_min=19, tm_sec=10, tm_wday=3, tm_yday=49, tm_isdst=-1), 1)
>>> cal.parse('one day after Thursday')
(time.struct_time(tm_year=2016, tm_mon=2, tm_mday=19, tm_hour=9, tm_min=0, tm_sec=0, tm_wday=4, tm_yday=50, tm_isdst=-1), 1)
>>> cal.parse('one day before Thursday')
(time.struct_time(tm_year=2016, tm_mon=2, tm_mday=17, tm_hour=9, tm_min=0, tm_sec=0, tm_wday=2, tm_yday=48, tm_isdst=-1), 1)
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/bear/parsedatetime/153)
<!-- Reviewable:end -->
