### PR TITLE
fix (by deletion?) "some duration before noon/dinner/etc"

### DIFF
--- a/parsedatetime/__init__.py
+++ b/parsedatetime/__init__.py
@@ -939,6 +939,16 @@ class Calendar(object):
                 sourceTime = target.timetuple()
             ctx.updateAccuracy(ctx.ACU_DAY)
 
+        elif chunk1 == '' and chunk2 == '' and self.ptc.CRE_TIME.match(unit):
+            m = self.ptc.CRE_TIME.match(unit)
+            debug and log.debug('CRE_TIME matched')
+            (yr, mth, dy, hr, mn, sec, wd, yd, isdst), subctx = \
+                self.parse(unit, None, VERSION_CONTEXT_STYLE)
+
+            start = datetime.datetime(yr, mth, dy, hr, mn, sec)
+            target = start + datetime.timedelta(days=offset)
+            sourceTime = target.timetuple()
+
         else:
             # check if the remaining text is parsable and if so,
             # use it as the base time for the modifier source time

--- a/parsedatetime/__init__.py
+++ b/parsedatetime/__init__.py
@@ -939,16 +939,6 @@ class Calendar(object):
                 sourceTime = target.timetuple()
             ctx.updateAccuracy(ctx.ACU_DAY)
 
-        elif self.ptc.CRE_TIME.match(unit):
-            m = self.ptc.CRE_TIME.match(unit)
-            debug and log.debug('CRE_TIME matched')
-            (yr, mth, dy, hr, mn, sec, wd, yd, isdst), subctx = \
-                self.parse(unit, None, VERSION_CONTEXT_STYLE)
-
-            start = datetime.datetime(yr, mth, dy, hr, mn, sec)
-            target = start + datetime.timedelta(days=offset)
-            sourceTime = target.timetuple()
-
         else:
             # check if the remaining text is parsable and if so,
             # use it as the base time for the modifier source time

--- a/tests/TestSimpleOffsetsNoon.py
+++ b/tests/TestSimpleOffsetsNoon.py
@@ -66,6 +66,18 @@ class test(unittest.TestCase):
         self.assertExpectedResult(
             self.cal.parse('5 hours before 12:00 pm', start), (target, 2))
 
+    def testOffsetBeforeModifiedNoon(self):
+        # A contrived test of two modifiers applied to noon - offset by
+        # -5 from the following day (-5 + 24)
+        s = datetime.datetime.now()
+        t = (datetime.datetime(self.yr, self.mth, self.dy, 12, 0, 0) +
+             datetime.timedelta(hours=-5 + 24))
+
+        start = s.timetuple()
+        target = t.timetuple()
+
+        self.assertExpectedResult(
+            self.cal.parse('5 hours before next noon', start), (target, 2))
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/TestSimpleOffsetsNoon.py
+++ b/tests/TestSimpleOffsetsNoon.py
@@ -40,10 +40,10 @@ class test(unittest.TestCase):
             self.cal.parse('5 hours after 12:00pm', start), (target, 2))
         self.assertExpectedResult(
             self.cal.parse('5 hours after 12:00 pm', start), (target, 2))
-        # self.assertExpectedResult(
-        #     self.cal.parse('5 hours after noon', start), (target, 2))
-        # self.assertExpectedResult(
-        #     self.cal.parse('5 hours from noon', start), (target, 2))
+        self.assertExpectedResult(
+            self.cal.parse('5 hours after noon', start), (target, 2))
+        self.assertExpectedResult(
+            self.cal.parse('5 hours from noon', start), (target, 2))
 
     def testOffsetBeforeNoon(self):
         s = datetime.datetime.now()
@@ -53,8 +53,8 @@ class test(unittest.TestCase):
         start = s.timetuple()
         target = t.timetuple()
 
-        # self.assertExpectedResult(
-        #     self.cal.parse('5 hours before noon', start), (target, 2))
+        self.assertExpectedResult(
+            self.cal.parse('5 hours before noon', start), (target, 2))
         self.assertExpectedResult(
             self.cal.parse('5 hours before 12pm', start), (target, 2))
         self.assertExpectedResult(


### PR DESCRIPTION
Fixes cases of relative times with CRE_TIME patterns like "noon", "lunch", etc, for example: `5 minutes before noon tomorrow`, `1 hour after dinner`.  These evaluations were getting offset by an entire day forward/backwards based on the word before or after.

```
# before
>>> pdt.Calendar().nlp("One hour after dinner") # today is 5/3
((datetime.datetime(2016, 5, 4, 20, 0), 2, 0, 21, 'One hour after dinner'),)

# after this change:
>>> pdt.Calendar().nlp("One hour after dinner")
((datetime.datetime(2016, 5, 3, 20, 0), 2, 0, 21, 'One hour after dinner'),)
```

This might be dangerous territory, but I cannot figure out the intention of the code which was causing this issue - I see that it has been copy/pasted/ported through a number of refactors and suspect that it has been made obsolete and is now only causing problems.  This PR fixes the scenarios stated above, and I cannot come up with any other modifier/cre_time pairing that would be parsed correctly with the old code.

The test cases for these scenarios were already written, but have been commented out for years!  This PR re-enables those tests and introduces no new failures.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/parsedatetime/160)
<!-- Reviewable:end -->
