### PR TITLE
update code example in readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -74,10 +74,9 @@ An example of how to use parsedatetime::
 To get it to a Python ``datetime`` object::
 
     from datetime import datetime
-    from time import mktime
 
     time_struct, parse_status = cal.parse("tomorrow")
-    datetime.fromtimestamp(mktime(time_struct))
+    datetime(*time_struct[:6])
 
 Parse datetime with timezone support (using pytz package)::
 


### PR DESCRIPTION
construct datetime object directly `datetime(*tt[:6])` instead of using `fromtimestamp(mktime(tt))` (timezone issues are more likely than leap seconds issues).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/parsedatetime/163)
<!-- Reviewable:end -->
