### PR TITLE
fix "ass" being interpreted as a time

### DIFF
--- a/parsedatetime/__init__.py
+++ b/parsedatetime/__init__.py
@@ -2547,7 +2547,7 @@ class Constants(object):
 
         self.RE_QUNITS = r'''\b(?P<qty>
                                  -?
-                                 (?:\d+(?:{decimal_mark}\d+|)|(?:{numbers})s)\s?
+                                 (?:\d+(?:{decimal_mark}\d+|)|(?:{numbers})\s)\s?
                                  (?P<qunits>{qunits})
                              )\b'''.format(**self.locale.re_values)
 

--- a/tests/TestComplexDateTimes.py
+++ b/tests/TestComplexDateTimes.py
@@ -139,7 +139,7 @@ class test(unittest.TestCase):
         self.assertExpectedResult(
             self.cal.parse('August 5th 12:00 pm', start), (target, 3))
 
-        if self.mth > 8 or (self.mth == 8 and self.dy > 5):
+        if self.mth > 8 or (self.mth == 8 and self.dy > 22):
             target = datetime(
                 self.yr + 1, 8, 22, 3, 26, 0).timetuple()
         else:

--- a/tests/TestNlp.py
+++ b/tests/TestNlp.py
@@ -127,3 +127,4 @@ class test(unittest.TestCase):
             "happen every week!!", start), None)
         self.assertExpectedResult(self.cal.nlp("$300", start), None)
         self.assertExpectedResult(self.cal.nlp("300ml", start), None)
+        self.assertExpectedResult(self.cal.nlp("nice ass", start), None)


### PR DESCRIPTION
Well, honestly this issue is immediately top of the list for "Most Amusing Bug of 2016".  We were puzzled as to why our app was behaving incorrectly whenever the word "ass" was used in a sentence.  We soon found that parsedatetime is treating "ass" as a time:

```
>>> import parsedatetime
>>> parsedatetime.Calendar().nlp("nice ass")
((datetime.datetime(2016, 8, 10, 20, 5, 35), 2, 5, 8, 'ass'),)
```

We tracked the issue down to a curious QUNITS regular expression which matches the word "a" as the number 1, the letter "s", and then another "s" for "seconds" (it would also match the word "ash" via the same logic with "hours").  We couldn't quite make sense of the second "s" in the regular expression and believe it should have been "\s" instead - making that change fixes the issue.

This PR also fixes a time-sensitive spec that started failing a couple of days ago.

cc @bgalbraith

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/parsedatetime/173)
<!-- Reviewable:end -->
