### PR TITLE
fix date interpretation when day is also provided (#165)

### DIFF
--- a/parsedatetime/__init__.py
+++ b/parsedatetime/__init__.py
@@ -1575,7 +1575,7 @@ class Calendar(object):
         """
         parseStr = None
         chunk1 = chunk2 = ''
-        
+
         ctx = self.currentContext
         log.debug('eval %s with context - %s, %s', s, ctx.hasDate, ctx.hasTime)
 

--- a/parsedatetime/__init__.py
+++ b/parsedatetime/__init__.py
@@ -1575,6 +1575,9 @@ class Calendar(object):
         """
         parseStr = None
         chunk1 = chunk2 = ''
+        
+        ctx = self.currentContext
+        log.debug('eval %s with context - %s, %s', s, ctx.hasDate, ctx.hasTime)
 
         # Weekday
         m = self.ptc.CRE_WEEKDAY.search(s)
@@ -1592,7 +1595,7 @@ class Calendar(object):
                     parseStr = s
                     s = ''
 
-        if parseStr:
+        if parseStr and not ctx.hasDate:
             debug and log.debug(
                 'found (weekday) [%s][%s][%s]', parseStr, chunk1, chunk2)
             sourceTime = self._evalWeekday(parseStr, sourceTime)

--- a/tests/TestComplexDateTimes.py
+++ b/tests/TestComplexDateTimes.py
@@ -152,6 +152,12 @@ class test(unittest.TestCase):
         self.assertExpectedResult(
             self.cal.parse('August 22nd 3:26 am', start), (target, 3))
 
+    def testDatesWithDay(self):
+        start = datetime(
+            self.yr, self.mth, self.dy, self.hr, self.mn, self.sec).timetuple()
+        target = datetime(2016, 8, 23, 17, 0, 0).timetuple()
+        self.assertExpectedResult(
+            self.cal.parse('tuesday august 23nd 2016 at 5pm', start), (target, 3))
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This fixes a scenario previously reported as #165, in which the date is parsed incorrectly when a day is provided (e.g. "tuesday august 23nd 2016 at 5pm").  This particular fix works by ignoring the day if the date is already parsed out - it might be more informative to actually compare the reference date to the parsed out day and log or produce an error if they're not consistent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/parsedatetime/178)
<!-- Reviewable:end -->
