### PR TITLE
Fixed override of the long time format for Australian locale

### DIFF
--- a/parsedatetime/pdt_locales/en_AU.py
+++ b/parsedatetime/pdt_locales/en_AU.py
@@ -14,8 +14,6 @@ dateFormats = {
     'short': 'd/MM/yy',
 }
 
-timeFormats = {
-    'long': timeFormats['full'],
-}
+timeFormats['long'] = timeFormats['full']
 
 dp_order = ['d', 'm', 'y']


### PR DESCRIPTION
I had an Australian user noticing errors due to missing "short" time format. As it turned out, every format except "long" was missing. The previous implementation accidentally removed all other formats.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/parsedatetime/180)
<!-- Reviewable:end -->
