### PR TITLE
Fix/time before next offset

### DIFF
--- a/parsedatetime/__init__.py
+++ b/parsedatetime/__init__.py
@@ -915,7 +915,8 @@ class Calendar(object):
                 # day-of-week, we want to start with target as the day
                 # in the current week.
                 dowOffset = offset
-                if modifier not in ['next', 'last', 'prior', 'previous']:
+                relativeModifier = modifier not in ['this', 'next', 'last', 'prior', 'previous']
+                if relativeModifier:
                     dowOffset = 0
 
                 wkdy = self.ptc.WeekdayOffsets[wkdy]
@@ -926,7 +927,7 @@ class Calendar(object):
                                           startMinute, startSecond)
                 target = start + datetime.timedelta(days=diff)
 
-                if chunk1 != '':
+                if chunk1 != '' and relativeModifier:
                     # consider "one day before thursday": we need to parse chunk1 ("one day")
                     # and apply according to the offset ("before"), rather than allowing the
                     # remaining parse step to apply "one day" without the offset direction.

--- a/tests/TestSimpleOffsets.py
+++ b/tests/TestSimpleOffsets.py
@@ -186,6 +186,23 @@ class test(unittest.TestCase):
         self.assertExpectedResult(self.cal.parse('next friday', start),
                                   (target, 1))
 
+    def testNextWeekDayWithTime(self):
+        start = datetime.datetime.now()
+        target = start + datetime.timedelta(days=4 + 7 - start.weekday())
+        target = target.replace(hour=13, minute=0, second=0)
+        target = target.timetuple()
+
+        self.assertExpectedResult(self.cal.parse('next friday at 1pm', start),
+                                  (target, 3))
+        self.assertExpectedResult(self.cal.parse('1pm next friday', start),
+                                  (target, 3))
+
+        target = start + datetime.timedelta(days=4 - start.weekday())
+        target = target.replace(hour=13, minute=0, second=0)
+        target = target.timetuple()
+        self.assertExpectedResult(self.cal.parse('1pm this friday', start),
+                                  (target, 3))
+
     def testWeekBeforeNow(self):
         s = datetime.datetime.now()
         t = s + datetime.timedelta(weeks=-1)


### PR DESCRIPTION
Fixes a scenario where there's a time before a modifier:

```
>>> parsedatetime.Calendar().parse("1pm next Friday")
(time.struct_time(tm_year=2016, tm_mon=9, tm_mday=2, tm_hour=4, tm_min=14, tm_sec=58, tm_wday=4, tm_yday=246, tm_isdst=-1), 3)
```

This addresses the immediate issue by differentiating between the modifiers a little more - "next Friday" is not the same as "after Friday".  There might be a deeper issue here of assuming that the first chunk is an offset (like "1 hour") when in fact, it could be a fully qualified time ("1 pm").

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/parsedatetime/183)
<!-- Reviewable:end -->
