### PR TITLE
Fixes false meridians (four-letter a*m* or p*m* words like "3 puma")

### DIFF
--- a/parsedatetime/pdt_locales/base.py
+++ b/parsedatetime/pdt_locales/base.py
@@ -102,7 +102,7 @@ re_values = {
     'timeseparator': ':',
     'rangeseparator': '-',
     'daysuffix': 'rd|st|nd|th',
-    'meridian': 'am|pm|a.m.|p.m.|a|p',
+    'meridian': r'am|pm|a\.m\.|p\.m\.|a|p',
     'qunits': 'h|m|s|d|w|y',
     'now': ['now', 'right now'],
 }

--- a/tests/TestSimpleDateTimes.py
+++ b/tests/TestSimpleDateTimes.py
@@ -145,6 +145,10 @@ class test(unittest.TestCase):
         self.assertExpectedResult(self.cal.parse('$300', start), (start, 0))
         self.assertExpectedResult(self.cal.parse('300ml', start), (start, 0))
 
+        # Should not parse as a time due to false meridian
+        self.assertExpectedResult(self.cal.parse('3 axmx', start), (start, 0))
+        self.assertExpectedResult(self.cal.parse('3 pxmx', start), (start, 0))
+
     def testDates(self):
         start = datetime.datetime(
             self.yr, self.mth, self.dy, self.hr, self.mn, self.sec).timetuple()


### PR DESCRIPTION
The meridian regex in the base locale used unescaped periods to match *a.m.* and *p.m.* which caused any four-character phrase matching that pattern to be interpreted as a meridian. I added tests to make sure that *3 axpx* and *3 pxmx* are not interpreted as times.

Note that most non-word characters like *3 p-x.* or *3 p m* will still match because the meridian regex also matches the single characters `p` and `a` followed by any word boundary. With `nlp` you can easily see that both of those cases match only the *3 p* portion.

I bumped into this problem while working on the nlp whitespace handling. It is a nice bite-sized fix, should be fine for inclusion in 2.2.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/parsedatetime/192)
<!-- Reviewable:end -->
