### PR TITLE
Avoid discarding periods and quotes in nlp and parse

### DIFF
--- a/parsedatetime/__init__.py
+++ b/parsedatetime/__init__.py
@@ -2486,12 +2486,12 @@ class Constants(object):
         # when the day is absent from the string
         self.RE_DATE3 = r'''(?P<date>
                                 (?:
-                                    (?:^|\s+)
+                                    (?:^|\s+|\b)
                                     (?P<mthname>
                                         {months}|{shortmonths}
                                     )\b\.?
                                     |
-                                    (?:^|\s+)
+                                    (?:^|\s+|\b)
                                     (?P<day>[1-9]|[012]\d|3[01])
                                     (?P<suffix>{daysuffix}|)\b
                                     (?!\s*(?:{timecomponents}))

--- a/parsedatetime/__init__.py
+++ b/parsedatetime/__init__.py
@@ -2468,9 +2468,9 @@ class Constants(object):
                                         (,)?
                                         (\s)*
                                     )
-                                    (?P<mthname>
-                                        \b({months}|{shortmonths})\b
-                                    )\s*
+                                    \b(?P<mthname>
+                                        {months}|{shortmonths}
+                                    )\b\.?\s*
                                     (?P<year>\d\d
                                         (\d\d)?
                                     )?
@@ -2489,7 +2489,7 @@ class Constants(object):
                                     (?:^|\s+)
                                     (?P<mthname>
                                         {months}|{shortmonths}
-                                    )\b
+                                    )\b\.?
                                     |
                                     (?:^|\s+)
                                     (?P<day>[1-9]|[012]\d|3[01])
@@ -2508,9 +2508,9 @@ class Constants(object):
         self.RE_MONTH = r'''(\s+|^)
                             (?P<month>
                                 (
-                                    (?P<mthname>
-                                        \b({months}|{shortmonths})\b
-                                    )
+                                    \b(?P<mthname>
+                                        {months}|{shortmonths}
+                                    )\b\.?
                                     (\s*
                                         (?P<year>(\d{{4}}))
                                     )?

--- a/parsedatetime/__init__.py
+++ b/parsedatetime/__init__.py
@@ -2584,7 +2584,7 @@ class Constants(object):
                                  )'''
 
         if 'meridian' in self.locale.re_values:
-            self.RE_TIMEHMS2 += (r'\s*(?P<meridian>{meridian})\b'
+            self.RE_TIMEHMS2 += (r'\s*(?P<meridian>{meridian})'
                                  .format(**self.locale.re_values))
         else:
             self.RE_TIMEHMS2 += r'\b'

--- a/parsedatetime/__init__.py
+++ b/parsedatetime/__init__.py
@@ -1812,10 +1812,6 @@ class Calendar(object):
         """
         debug and log.debug('parse()')
 
-        datetimeString = re.sub(r'(\w)\.(\s)', r'\1\2', datetimeString)
-        datetimeString = re.sub(r'(\w)[\'"](\s|$)', r'\1 \2', datetimeString)
-        datetimeString = re.sub(r'(\s|^)[\'"](\w)', r'\1 \2', datetimeString)
-
         if sourceTime:
             if isinstance(sourceTime, datetime.datetime):
                 debug and log.debug('coercing datetime to timetuple')
@@ -1962,13 +1958,7 @@ class Calendar(object):
 
         orig_inputstring = inputString
 
-        # replace periods at the end of sentences w/ spaces
-        # opposed to removing them altogether in order to
-        # retain relative positions (identified by alpha, period, space).
-        # this is required for some of the regex patterns to match
-        inputString = re.sub(r'(\w)(\.)(\s)', r'\1 \3', inputString).lower()
-        inputString = re.sub(r'(\w)(\'|")(\s|$)', r'\1 \3', inputString)
-        inputString = re.sub(r'(\s|^)(\'|")(\w)', r'\1 \3', inputString)
+        inputString = inputString.lower()
 
         startpos = 0  # the start position in the inputString during the loop
 

--- a/parsedatetime/__init__.py
+++ b/parsedatetime/__init__.py
@@ -2574,13 +2574,13 @@ class Constants(object):
         # 1, 2, and 3 here refer to the type of match date, time, or units
         self.RE_NLP_PREFIX = r'''\b(?P<nlp_prefix>
                                   (on)
-                                  (\s)+1
+                                  [\s(\["'-]+1
                                   |
                                   (at|in)
-                                  (\s)+2
+                                  [\s(\["'-]+2
                                   |
                                   (in)
-                                  (\s)+3
+                                  [\s(\["'-]+3
                                  )'''
 
         if 'meridian' in self.locale.re_values:

--- a/parsedatetime/pdt_locales/base.py
+++ b/parsedatetime/pdt_locales/base.py
@@ -102,7 +102,7 @@ re_values = {
     'timeseparator': ':',
     'rangeseparator': '-',
     'daysuffix': 'rd|st|nd|th',
-    'meridian': r'am|pm|a\.m\.|p\.m\.|a|p',
+    'meridian': r'a\.m\.|p\.m\.|(?:am|pm|a|p)\b',
     'qunits': 'h|m|s|d|w|y',
     'now': ['now', 'right now'],
 }

--- a/tests/TestNlp.py
+++ b/tests/TestNlp.py
@@ -128,3 +128,144 @@ class test(unittest.TestCase):
         self.assertExpectedResult(self.cal.nlp("$300", start), None)
         self.assertExpectedResult(self.cal.nlp("300ml", start), None)
         self.assertExpectedResult(self.cal.nlp("nice ass", start), None)
+
+    def testTimes(self):
+        start = datetime.datetime(
+            self.yr, self.mth, self.dy, self.hr, self.mn, self.sec).timetuple()
+        targets = {
+            datetime.datetime(self.yr, self.mth, self.dy, 23, 0, 0): (
+                '11:00:00 PM',
+                '11:00 PM',
+                '11 PM',
+                '11PM',
+                '2300',
+                '23:00',
+                '11p',
+                '11pm',
+                '11:00:00 P.M.',
+                '11:00 P.M.',
+                '11 P.M.',
+                '11P.M.',
+                '11p.m.',
+                '11 p.m.',
+            ),
+            datetime.datetime(self.yr, self.mth, self.dy, 11, 0, 0): (
+                '11:00:00 AM',
+                '11:00 AM',
+                '11 AM',
+                '11AM',
+                '1100',
+                '11:00',
+                '11a',
+                '11am',
+                '11:00:00 A.M.',
+                '11:00 A.M.',
+                '11 A.M.',
+                '11A.M.',
+                '11a.m.',
+                '11 a.m.',
+            ),
+            datetime.datetime(self.yr, self.mth, self.dy, 7, 30, 0): (
+                '730',
+                '0730',
+                '0730am',
+            ),
+            datetime.datetime(self.yr, self.mth, self.dy, 17, 30, 0): (
+                '1730',
+                '173000',
+            )
+        }
+
+        for dt, phrases in targets.items():
+            # Time (2) phrase starting at index 0
+            target = (dt, 2, 0)
+            for phrase in phrases:
+                self.assertExpectedResult(
+                    self.cal.nlp(phrase, start),
+                    (target + (len(phrase), phrase),)
+                )
+
+            # Wrap in quotes
+            target = (dt, 2, 1)
+            for phrase in phrases:
+                self.assertExpectedResult(
+                    self.cal.nlp('"%s"' % phrase, start),
+                    (target + (len(phrase) + 1, phrase),)
+                )
+
+    def testFalsePositiveTimes(self):
+        start = datetime.datetime(
+            self.yr, self.mth, self.dy, self.hr, self.mn, self.sec).timetuple()
+        phrases = (
+            '$300',
+            '300ml',
+            '3:2',
+        )
+
+        for phrase in phrases:
+            self.assertExpectedResult(
+                self.cal.nlp(phrase, start), None)
+
+    def testDates(self):
+        # Set month to January to avoid issues with August being interpreted
+        # as next year when tests are run after Aug 25
+        start = datetime.datetime(
+            self.yr, 1, self.dy, self.hr, self.mn, self.sec).timetuple()
+        targets = {
+            datetime.datetime(2006, 8, 25, self.hr, self.mn, self.sec): (
+                '08/25/2006',
+                '08.25.2006',
+                '2006/08/25',
+                '2006/8/25',
+                '2006-08-25',
+                '8/25/06',
+                'August 25, 2006',
+                'Aug 25, 2006',
+                'Aug. 25, 2006',
+                'August 25 2006',
+                'Aug 25 2006',
+                'Aug. 25 2006',
+                '25 August 2006',
+                '25 Aug 2006',
+            ),
+            datetime.datetime(self.yr, 8, 25, self.hr, self.mn, self.sec): (
+                '8/25',
+                '8.25',
+                '08/25',
+                'August 25',
+                'Aug 25',
+                'Aug. 25',
+            ),
+            datetime.datetime(2006, 8, 1, self.hr, self.mn, self.sec): (
+                'Aug. 2006',
+            )
+        }
+
+        for dt, phrases in targets.items():
+            # Date (1) phrase starting at index 0
+            target = (dt, 1, 0)
+            for phrase in phrases:
+                self.assertExpectedResult(
+                    self.cal.nlp(phrase, start),
+                    (target + (len(phrase), phrase),)
+                )
+
+            # Wrap in quotes
+            target = (dt, 1, 1)
+            for phrase in phrases:
+                self.assertExpectedResult(
+                    self.cal.nlp('"%s"' % phrase, start),
+                    (target + (len(phrase) + 1, phrase),)
+                )
+
+    def testFalsePositiveDates(self):
+        start = datetime.datetime(
+            self.yr, self.mth, self.dy, self.hr, self.mn, self.sec).timetuple()
+        phrases = (
+            '$1.23',
+            '$12.34'
+        )
+
+        for phrase in phrases:
+            self.assertExpectedResult(
+                self.cal.nlp(phrase, start), None)


### PR DESCRIPTION
As discussed in #181 it should be possible to remove the pre-processing in `nlp` and `parse` to remove periods followed by spaces and quotes followed or preceded by spaces since the regular expressions now use word boundaries. There are several things that I want to discuss in this pull request.

I am not yet fully convinced that removing the pre-processing is necessary. It caused minor problems with meridian and month abbreviations and took a bit more regex cleanup to fix than I anticipated. There is a discussion below on testing, I think that more comprehensive testing will be necessary before merging this to v3.

The basic problems involved the phrase not quite matching what you would expect:

``` python
>>> cal.nlp('5 A.M.')
((datetime.datetime(2016, 9, 10, 5, 0), 2, 0, 3, '5 A'),)
>>> cal.nlp('Aug.')
((datetime.datetime(2017, 8, 1, 9, 41, 35), 1, 0, 3, 'Aug'),)
>>> cal.nlp('"august"')
((datetime.datetime(2017, 8, 1, 9, 44, 13), 1, 0, 7, '"august'),)
```

After these changes the results are improved:

```python
>>> cal.nlp('5 A.M.')
((datetime.datetime(2016, 9, 10, 5, 0), 2, 0, 6, '5 A.M.'),)
>>> cal.nlp('Aug.')
((datetime.datetime(2017, 8, 1, 9, 41, 35), 1, 0, 4, 'Aug.'),)
>>> cal.nlp('"august"')
((datetime.datetime(2017, 8, 1, 9, 44, 13), 1, 1, 7, 'august'),)
```

### Meridian

In order to support *A.M.* format with periods I had to move the word boundary from the parsing regex into the locale which is very messy: `'meridian': r'a\.m\.|p\.m\.|(?:am|pm|a|p)\b',`. Otherwise, `a\.m\.\b` won't match because there is no word boundary on that side of the period. Some of our discussions about how locales are specified might lead to a better solution.

### Test format

I started a discussion in #196 about improvements to testing. This pull request included some very minor improvements to tests when I ported over tests from `parse` to `nlp`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/parsedatetime/195)
<!-- Reviewable:end -->
