### PR TITLE
Allow day start hour to be configurable - by default 9 as now

### DIFF
--- a/parsedatetime/__init__.py
+++ b/parsedatetime/__init__.py
@@ -22,7 +22,6 @@ Parse human-readable date/time text.
 
 Requires Python 2.6 or later
 """
-
 from __future__ import with_statement, absolute_import, unicode_literals
 
 import re
@@ -243,7 +242,7 @@ def _parse_date_rfc822(dateString):
 
 VERSION_FLAG_STYLE = 1
 VERSION_CONTEXT_STYLE = 2
-
+DEFAULT_DAY_START_HOUR = 9
 
 class Calendar(object):
 
@@ -252,7 +251,8 @@ class Calendar(object):
     The text can either be 'normal' date values or it can be human readable.
     """
 
-    def __init__(self, constants=None, version=VERSION_FLAG_STYLE):
+    def __init__(self, constants=None, version=VERSION_FLAG_STYLE,
+                 day_start_hour=DEFAULT_DAY_START_HOUR):
         """
         Default constructor for the L{Calendar} class.
 
@@ -280,6 +280,7 @@ class Calendar(object):
                 'with argument `version=parsedatetime.VERSION_CONTEXT_STYLE`.',
                 pdt20DeprecationWarning)
         self._ctxStack = pdtContextStack()
+        self.day_start_hour = day_start_hour
 
     @contextlib.contextmanager
     def context(self):
@@ -790,7 +791,7 @@ class Calendar(object):
             startMinute = mn
             startSecond = sec
         else:
-            startHour = 9
+            startHour = self.day_start_hour
             startMinute = 0
             startSecond = 0
 
@@ -1142,7 +1143,7 @@ class Calendar(object):
             startMinute = mn
             startSecond = sec
         else:
-            startHour = 9
+            startHour = self.day_start_hour
             startMinute = 0
             startSecond = 0
 

--- a/parsedatetime/__init__.py
+++ b/parsedatetime/__init__.py
@@ -262,6 +262,9 @@ class Calendar(object):
         @param version:   Default style version of current Calendar instance.
                           Valid value can be 1 (L{VERSION_FLAG_STYLE}) or
                           2 (L{VERSION_CONTEXT_STYLE}). See L{parse()}.
+        @type  day_start_hour: int
+        @param day_start_hour: Hour to set a datetime when no time has been
+                               specified.
 
         @rtype:  object
         @return: L{Calendar} instance

--- a/tests/TestDayStartHour.py
+++ b/tests/TestDayStartHour.py
@@ -1,0 +1,61 @@
+# -*- coding: utf-8 -*-
+"""
+Test parsing of strings that are phrases
+"""
+from __future__ import unicode_literals
+
+import sys
+import time
+import datetime
+import parsedatetime as pdt
+from . import utils
+
+if sys.version_info < (2, 7):
+    import unittest2 as unittest
+else:
+    import unittest
+
+
+class test(unittest.TestCase):
+
+    @utils.assertEqualWithComparator
+    def assertExpectedResult(self, result, check, **kwargs):
+        return utils.compareResultByTimeTuplesAndFlags(result, check, **kwargs)
+
+    def setUp(self):
+        # Test with a different day start hour.
+        (self.yr, self.mth, self.dy, self.hr,
+         self.mn, self.sec, self.wd, self.yd, self.isdst) = time.localtime()
+
+    def testDifferentDayStartHours(self):
+        for day_start_hour in (0, 6, 9, 12):
+            cal = pdt.Calendar(
+                day_start_hour=day_start_hour)
+
+            s = datetime.datetime.now()
+            t = datetime.datetime(
+                self.yr, self.mth, self.dy,
+                day_start_hour, 0, 0) + datetime.timedelta(days=1)
+
+            start = s.timetuple()
+            target = t.timetuple()
+
+            self.assertExpectedResult(
+                cal.parse('tomorrow', start), (target, 1))
+            self.assertExpectedResult(
+                cal.parse('next day', start), (target, 1))
+
+            t = datetime.datetime(
+                self.yr, self.mth, self.dy,
+                day_start_hour, 0, 0) + datetime.timedelta(days=-1)
+            target = t.timetuple()
+
+            self.assertExpectedResult(
+                cal.parse('yesterday', start), (target, 1))
+
+            t = datetime.datetime(
+                self.yr, self.mth, self.dy,
+                day_start_hour, 0, 0)
+            target = t.timetuple()
+
+            self.assertExpectedResult(cal.parse('today', start), (target, 1))

--- a/tests/TestLocaleBase.py
+++ b/tests/TestLocaleBase.py
@@ -142,10 +142,13 @@ class TestDayOffsets(test):
         self.__old_pdtlocale_fr = pdt.pdtLocales.get('fr_FR')  # save for later
         pdt.pdtLocales['fr_FR'] = pdtLocale_fr  # override for the test
         self.ptc = pdt.Constants('fr_FR', usePyICU=False)
-        self.cal = pdt.Calendar(self.ptc)
+        self.day_start_hour = 9
+        self.cal = pdt.Calendar(
+            self.ptc, day_start_hour=self.day_start_hour)
 
     def test_dayoffsets(self):
-        start = datetime.datetime(self.yr, self.mth, self.dy, 9)
+        start = datetime.datetime(self.yr, self.mth, self.dy,
+                                  self.day_start_hour)
         for date_string, expected_day_offset in [
                 ("Aujourd'hui", 0),
                 ("aujourd'hui", 0),

--- a/tests/TestNlp.py
+++ b/tests/TestNlp.py
@@ -57,7 +57,9 @@ class test(unittest.TestCase):
         return True
 
     def setUp(self):
-        self.cal = pdt.Calendar()
+        self.day_start_hour = 9
+        self.cal = pdt.Calendar(
+            day_start_hour=self.day_start_hour)
         (self.yr, self.mth, self.dy, self.hr,
          self.mn, self.sec, self.wd, self.yd, self.isdst) = time.localtime()
 
@@ -75,7 +77,7 @@ class test(unittest.TestCase):
                    3, 72, 90, 'next Friday at 9PM'),
                   (datetime.datetime(2013, 8, 1, 21, 30, 0),
                    2, 120, 132, 'in 5 minutes'),
-                  (datetime.datetime(2013, 8, 8, 9, 0),
+                  (datetime.datetime(2013, 8, 8, self.day_start_hour, 0),
                    1, 173, 182, 'next week'))
 
         # positive testing

--- a/tests/TestPhrases.py
+++ b/tests/TestPhrases.py
@@ -23,7 +23,9 @@ class test(unittest.TestCase):
         return utils.compareResultByTimeTuplesAndFlags(result, check, **kwargs)
 
     def setUp(self):
-        self.cal = pdt.Calendar()
+        self.day_start_hour = 9
+        self.cal = pdt.Calendar(
+            day_start_hour=self.day_start_hour)
         (self.yr, self.mth, self.dy, self.hr,
          self.mn, self.sec, self.wd, self.yd, self.isdst) = time.localtime()
 
@@ -114,8 +116,9 @@ class test(unittest.TestCase):
             mth = 1
             yr += 1
 
-        t = datetime.datetime(
-            yr, mth, 1, 9, 0, 0) + datetime.timedelta(days=-1)
+        t = (datetime.datetime(
+            yr, mth, 1, self.day_start_hour, 0, 0)
+             + datetime.timedelta(days=-1))
 
         start = s.timetuple()
         target = t.timetuple()
@@ -129,7 +132,8 @@ class test(unittest.TestCase):
 
         (yr, mth, dy, hr, mn, sec, wd, yd, isdst) = s.timetuple()
 
-        t = datetime.datetime(yr, 12, 31, 9, 0, 0)
+        t = datetime.datetime(
+            yr, 12, 31, self.day_start_hour, 0, 0)
 
         start = s.timetuple()
         target = t.timetuple()

--- a/tests/TestSimpleOffsets.py
+++ b/tests/TestSimpleOffsets.py
@@ -39,7 +39,9 @@ class test(unittest.TestCase):
         return utils.compareResultByTimeTuplesAndFlags(result, check, **kwargs)
 
     def setUp(self):
-        self.cal = pdt.Calendar()
+        self.day_start_hour = 9
+        self.cal = pdt.Calendar(
+            day_start_hour=self.day_start_hour)
         (self.yr, self.mth, self.dy, self.hr,
          self.mn, self.sec, self.wd, self.yd, self.isdst) = time.localtime()
 
@@ -253,7 +255,8 @@ class test(unittest.TestCase):
     def testSpecials(self):
         s = datetime.datetime.now()
         t = datetime.datetime(
-            self.yr, self.mth, self.dy, 9, 0, 0) + datetime.timedelta(days=1)
+            self.yr, self.mth, self.dy,
+            self.day_start_hour, 0, 0) + datetime.timedelta(days=1)
 
         start = s.timetuple()
         target = t.timetuple()
@@ -264,13 +267,16 @@ class test(unittest.TestCase):
             self.cal.parse('next day', start), (target, 1))
 
         t = datetime.datetime(
-            self.yr, self.mth, self.dy, 9, 0, 0) + datetime.timedelta(days=-1)
+            self.yr, self.mth, self.dy,
+            self.day_start_hour, 0, 0) + datetime.timedelta(days=-1)
         target = t.timetuple()
 
         self.assertExpectedResult(
             self.cal.parse('yesterday', start), (target, 1))
 
-        t = datetime.datetime(self.yr, self.mth, self.dy, 9, 0, 0)
+        t = datetime.datetime(
+            self.yr, self.mth, self.dy,
+            self.day_start_hour, 0, 0)
         target = t.timetuple()
 
         self.assertExpectedResult(self.cal.parse('today', start), (target, 1))


### PR DESCRIPTION
When creating a Calendar, allow the day start hour to be passed in.
By default, remains at 9 - the way it currently is.

<!-- Reviewable:start -->

---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/parsedatetime/203)
<!-- Reviewable:end -->
