### PR TITLE
fix(setup, #219): drop `setup_requires` from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,6 @@ setup(
     platforms=['Any'],
     long_description=read('README.rst'),
     install_requires=['future'],
-    setup_requires=['pytest-runner'],
     tests_require=['pytest'],
     test_suite='tests',
     classifiers=[


### PR DESCRIPTION
- The `pytest_runner` dep exists in testing-requirements that is sourced
by `tox.ini`, so it should work.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/parsedatetime/220)
<!-- Reviewable:end -->
