### PR TITLE
Fix lint errors for flake8 v3.5.0

### DIFF
--- a/parsedatetime/pdt_locales/icu.py
+++ b/parsedatetime/pdt_locales/icu.py
@@ -138,10 +138,10 @@ def get_icu(locale):
 
     result['dateSep'] = [ds]
     s = result['dateFormats']['short']
-    l = s.lower().split(ds)
+    ll = s.lower().split(ds)
     dp_order = []
 
-    for s in l:
+    for s in ll:
         if len(s) > 0:
             dp_order.append(s[:1])
 

--- a/parsedatetime/pdt_locales/nl_NL.py
+++ b/parsedatetime/pdt_locales/nl_NL.py
@@ -71,7 +71,6 @@ Modifiers = {
     'vanaf': 1,
     'voor': -1,
     'na': 1,
-    'vorige': -1,
     'eervorige': -1,
     'prev': -1,
     'laastste': -1,


### PR DESCRIPTION
Fixes parsedatetime lint errors for flake8 v3.5.0 (mccabe: 0.6.1, pycodestyle: 2.3.1, pyflakes: 1.6.0).   Required to be fixed before tests will run.  The nl_NL.py error references "different values" for 'vorige' key, but to my eye they are the same.

```
$ make test
flake8 parsedatetime > violations.flake8.txt
Makefile:54: recipe for target 'lint' failed
make: *** [lint] Error 1
$ cat violations.flake8.txt
parsedatetime/pdt_locales/icu.py:141:5: E741 ambiguous variable name 'l'
parsedatetime/pdt_locales/nl_NL.py:74:5: F601 dictionary key 'vorige' repeated with different values
parsedatetime/pdt_locales/nl_NL.py:80:5: F601 dictionary key 'vorige' repeated with different values
$ flake8 --version
3.5.0 (mccabe: 0.6.1, pycodestyle: 2.3.1, pyflakes: 1.6.0) CPython 3.5.2 on Linux
$ git rev-parse HEAD
830775dc5e36395622b41f12317f5e10c303d3a2
```

Link to code in question:
 - https://github.com/bear/parsedatetime/blob/830775dc5e36395622b41f12317f5e10c303d3a2/parsedatetime/pdt_locales/icu.py#L141
 - https://github.com/bear/parsedatetime/blob/830775dc5e36395622b41f12317f5e10c303d3a2/parsedatetime/pdt_locales/nl_NL.py#L74
 - https://github.com/bear/parsedatetime/blob/830775dc5e36395622b41f12317f5e10c303d3a2/parsedatetime/pdt_locales/nl_NL.py#L80

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/parsedatetime/224)
<!-- Reviewable:end -->
