### PR TITLE
Add a constant for start hour

### DIFF
--- a/parsedatetime/__init__.py
+++ b/parsedatetime/__init__.py
@@ -790,7 +790,7 @@ class Calendar(object):
             startMinute = mn
             startSecond = sec
         else:
-            startHour = 9
+            startHour = self.ptc.StartHour
             startMinute = 0
             startSecond = 0
 
@@ -1142,7 +1142,7 @@ class Calendar(object):
             startMinute = mn
             startSecond = sec
         else:
-            startHour = 9
+            startHour = self.ptc.StartHour
             startMinute = 0
             startSecond = 0
 
@@ -2313,9 +2313,14 @@ class Constants(object):
         self.BirthdayEpoch = 50
 
         # When True the starting time for all relative calculations will come
-        # from the given SourceTime, otherwise it will be 9am
+        # from the given SourceTime, otherwise it will be self.StartHour
 
         self.StartTimeFromSourceTime = False
+
+        # The hour of the day that will be used as the starting time for all
+        # relative calculations when self.StartTimeFromSourceTime is False
+
+        self.StartHour = 9
 
         # YearParseStyle controls how we parse "Jun 12", i.e. dates that do
         # not have a year present.  The default is to compare the date given


### PR DESCRIPTION
Adds a constant specifying the start hour for all relative calculations when self.StartTimeFromSourceTime is False.

parsedatetime uses 09:00 as the start of the day for relative calculations, but that time is not currently configurable.   09:00 is the traditional start of the workday in the the US and other countries, but in many countries 07:00 or 08:00 is traditional. 

There's also a use case for being able to set the start of the day to 00:00:00.

I considered adding configuration to set hour/minute/second, but thought just hour would satisfy most use cases and require less code change.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/parsedatetime/225)
<!-- Reviewable:end -->
