### PR TITLE
fix pyicu import to suppress warnings

### DIFF
--- a/parsedatetime/pdt_locales/icu.py
+++ b/parsedatetime/pdt_locales/icu.py
@@ -13,9 +13,12 @@ except NameError:
     pass
 
 try:
-    import PyICU as pyicu
+    import icu as pyicu
 except ImportError:
-    pyicu = None
+    try:
+        import PyICU as pyicu
+    except ImportError:
+        pyicu = None
 
 
 def icu_object(mapping):


### PR DESCRIPTION
Newer versions of pyicu should be imported as

    import icu 

whereas

    import PyICU 

will print a warning.

This fix uses the preferred import if available and otherwise falls back to the older name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/parsedatetime/242)
<!-- Reviewable:end -->
