### PR TITLE
 pyicu 'module' object has no attribute 'Locale'

### DIFF
--- a/parsedatetime/pdt_locales/icu.py
+++ b/parsedatetime/pdt_locales/icu.py
@@ -13,12 +13,9 @@ except NameError:
     pass
 
 try:
-    import icu as pyicu
+    import PyICU as pyicu
 except ImportError:
-    try:
-        import PyICU as pyicu
-    except ImportError:
-        pyicu = None
+    pyicu = None
 
 
 def icu_object(mapping):


### PR DESCRIPTION
``
File "/usr/local/lib/python2.7/dist-packages/parsedatetime/pdt_locales/icu.py", line 56, in get_icu
result['icu'] = icu = pyicu.Locale(locale)
AttributeError: 'module' object has no attribute 'Locale'
``
Hi all.

The https://github.com/openaps/openaps project (very indirectly) uses `parsedatetime` and in the last few weeks a problem has emerged with `AttributeError: 'module' object has no attribute 'Locale'`. This PR _seems_ to fix it - at least in how we're using it.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/parsedatetime/248)
<!-- Reviewable:end -->
