### PR TITLE
Include pytest.ini in source distributions, fixes tests

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,6 +1,7 @@
 include *.rst
 include *.txt
 include Makefile
+include pytest.ini
 recursive-include examples *.py
 recursive-include examples *.txt
 recursive-include tests *.py


### PR DESCRIPTION
Hi,
This is needed, otherwise none of the test files (named `Test*.py`) are found by pytest.