### PR TITLE
Logging in Python 3 is a bit different, especially within a module

### DIFF
--- a/parsedatetime/__init__.py
+++ b/parsedatetime/__init__.py
@@ -50,9 +50,7 @@ __download_url__ = 'https://pypi.python.org/pypi/parsedatetime'
 __description__ = 'Parse human-readable date/time text.'
 
 
-log = logging.getLogger(__name__)
 debug = False
-
 pdtLocales = dict([(x, load_locale(x)) for x in _locales])
 
 
@@ -327,8 +325,8 @@ class Calendar(object):
         @return: C{struct_time} of the calculated time
         """
         ctx = self.currentContext
-        debug and log.debug('_buildTime: [%s][%s][%s]',
-                            quantity, modifier, units)
+        print('** ', debug)
+        debug and logging.debug(f'_buildTime: [{quantity}][{modifier}][{units}]')
 
         if source is None:
             source = time.localtime()
@@ -360,8 +358,7 @@ class Calendar(object):
                 realunit = key
                 break
 
-        debug and log.debug('units %s --> realunit %s (qty=%s)',
-                            units, realunit, qty)
+        debug and logging.debug(f'units {units} --> realunit {realunit} (qty={qty})')
 
         try:
             if realunit in ('years', 'months'):
@@ -452,8 +449,7 @@ class Calendar(object):
             yr += 1900
 
         daysInCurrentMonth = self.ptc.daysInMonth(mth, yr)
-        debug and log.debug('parseDate: %s %s %s %s',
-                            yr, mth, dy, daysInCurrentMonth)
+        debug and logging.debug(f'parseDate: {yr} {mth} {dy} {daysInCurrentMonth}')
 
         with self.context() as ctx:
             if mth > 0 and mth <= 12 and dy > 0 and \
@@ -491,8 +487,7 @@ class Calendar(object):
         currentDy = dy
         accuracy = []
 
-        debug and log.debug('parseDateText currentMth %s currentDy %s',
-                            mth, dy)
+        debug and logging.debug(f'parseDateText currentMth {mth} currentDy {dy}')
 
         s = dateString.lower()
         m = self.ptc.CRE_DATE3.search(s)
@@ -529,9 +524,7 @@ class Calendar(object):
                 # Return current time if date string is invalid
                 sourceTime = time.localtime()
 
-        debug and log.debug('parseDateText returned '
-                            'mth %d dy %d yr %d sourceTime %s',
-                            mth, dy, yr, sourceTime)
+        debug and logging.debug(f'parseDateText returned mth {mth} dy {dy} yr {yr} sourceTime {sourceTime}')
 
         return sourceTime
 
@@ -569,7 +562,7 @@ class Calendar(object):
                 rangeFlag = rflag
                 break
 
-        debug and log.debug('evalRanges: rangeFlag = %s [%s]', rangeFlag, s)
+        debug and logging.debug(f'evalRanges: rangeFlag = {rangeFlag} [{s}]')
 
         if m is not None:
             if (m.group() != s):
@@ -715,9 +708,7 @@ class Calendar(object):
         elif style == -1 and diff > 7:
             diff -= 7
 
-        debug and log.debug("wd %s, wkdy %s, offset %d, "
-                            "style %d, currentDayStyle %d",
-                            wd, wkdy, origOffset, style, currentDayStyle)
+        debug and logging.debug(f'wd {wd}, wkdy {wkdy}, offset {origOffset}, style {style}, currentDayStyle {currentDayStyle}')
 
         return diff
 
@@ -791,9 +782,7 @@ class Calendar(object):
             unit = chunk2
             chunk2 = ''
 
-        debug and log.debug("modifier [%s] chunk1 [%s] "
-                            "chunk2 [%s] unit [%s]",
-                            modifier, chunk1, chunk2, unit)
+        debug and logging.debug(f'modifier [{modifier}] chunk1 [{chunk1}] chunk2 [{chunk2}] unit [{unit}]')
 
         if unit in self.ptc.units['months']:
             currentDaysInMonth = self.ptc.daysInMonth(mth, yr)
@@ -884,7 +873,7 @@ class Calendar(object):
 
         elif self.ptc.CRE_WEEKDAY.match(unit):
             m = self.ptc.CRE_WEEKDAY.match(unit)
-            debug and log.debug('CRE_WEEKDAY matched')
+            debug and logging.debug('CRE_WEEKDAY matched')
             wkdy = m.group()
 
             if modifier == 'eod':
@@ -928,7 +917,7 @@ class Calendar(object):
 
         elif chunk1 == '' and chunk2 == '' and self.ptc.CRE_TIME.match(unit):
             m = self.ptc.CRE_TIME.match(unit)
-            debug and log.debug('CRE_TIME matched')
+            debug and logging.debug('CRE_TIME matched')
             (yr, mth, dy, hr, mn, sec, wd, yd, isdst), subctx = \
                 self.parse(unit, None, VERSION_CONTEXT_STYLE)
 
@@ -997,9 +986,7 @@ class Calendar(object):
             # check if the remaining text is parsable and if so,
             # use it as the base time for the modifier source time
 
-            debug and log.debug('check for modifications '
-                                'to source time [%s] [%s]',
-                                chunk1, unit)
+            debug and logging.debug(f'check for modifications to source time [{chunk1}] [{unit}]')
 
             unit = unit.strip()
             if unit:
@@ -1033,7 +1020,7 @@ class Calendar(object):
                     pass
                 else:
                     qty = None
-                    debug and log.debug('CRE_NUMBER matched')
+                    debug and logging.debug('CRE_NUMBER matched')
                     qty = self._quantityToReal(m.group()) * offset
                     chunk1 = '%s%s%s' % (chunk1[:m.start()],
                                          qty, chunk1[m.end():])
@@ -1045,15 +1032,14 @@ class Calendar(object):
                 if subctx.hasDateOrTime:
                     sourceTime = t
 
-            debug and log.debug('looking for modifier %s', modifier)
+            debug and logging.debug(f'looking for modifier {modifier}')
             sTime = self.ptc.getSource(modifier, sourceTime)
             if sTime is not None:
-                debug and log.debug('modifier found in sources')
+                debug and logging.debug('modifier found in sources')
                 sourceTime = sTime
                 ctx.updateAccuracy(ctx.ACU_HALFDAY)
 
-        debug and log.debug('returning chunk = "%s %s" and sourceTime = %s',
-                            chunk1, chunk2, sourceTime)
+        debug and logging.debug(f'returning chunk = "{chunk1} {chunk2}" and sourceTime = {sourceTime}')
 
         return '%s %s' % (chunk1, chunk2), sourceTime
 
@@ -1083,7 +1069,7 @@ class Calendar(object):
         # Given string date is a RFC822 date
         if sourceTime is None:
             sourceTime = _parse_date_rfc822(s)
-            debug and log.debug(
+            debug and logging.debug(
                 'attempt to parse as rfc822 - %s', str(sourceTime))
 
             if sourceTime is not None:
@@ -1152,7 +1138,7 @@ class Calendar(object):
         sourceTime = self._evalDT(datetimeString, sourceTime)
 
         # Given string is in the format  "May 23rd, 2005"
-        debug and log.debug('checking for MMM DD YYYY')
+        debug and logging.debug('checking for MMM DD YYYY')
         return self.parseDateText(s, sourceTime)
 
     def _evalDateStd(self, datetimeString, sourceTime):
@@ -1353,8 +1339,7 @@ class Calendar(object):
                 parseStr = s
 
         if parseStr:
-            debug and log.debug('found (modifier) [%s][%s][%s]',
-                                parseStr, chunk1, chunk2)
+            debug and logging.debug(f'found (modifier) [{parseStr}][{chunk1}][{chunk2}]')
             s, sourceTime = self._evalModifier(parseStr, chunk1,
                                                chunk2, sourceTime)
 
@@ -1380,9 +1365,9 @@ class Calendar(object):
         # Quantity + Units
         m = self.ptc.CRE_UNITS.search(s)
         if m is not None:
-            debug and log.debug('CRE_UNITS matched')
+            debug and logging.debug('CRE_UNITS matched')
             if self._UnitsTrapped(s, m, 'units'):
-                debug and log.debug('day suffix trapped by unit match')
+                debug and logging.debug('day suffix trapped by unit match')
             else:
                 if (m.group('qty') != s):
                     # capture remaining string
@@ -1400,8 +1385,7 @@ class Calendar(object):
                     s = ''
 
         if parseStr:
-            debug and log.debug('found (units) [%s][%s][%s]',
-                                parseStr, chunk1, chunk2)
+            debug and logging.debug(f'found (units) [{parseStr}][{chunk1}][{chunk2}]')
             sourceTime = self._evalUnits(parseStr, sourceTime)
 
         return s, sourceTime, bool(parseStr)
@@ -1426,10 +1410,9 @@ class Calendar(object):
         # Quantity + Units
         m = self.ptc.CRE_QUNITS.search(s)
         if m is not None:
-            debug and log.debug('CRE_QUNITS matched')
+            debug and logging.debug('CRE_QUNITS matched')
             if self._UnitsTrapped(s, m, 'qunits'):
-                debug and log.debug(
-                    'day suffix trapped by qunit match')
+                debug and logging.debug('day suffix trapped by qunit match')
             else:
                 if (m.group('qty') != s):
                     # capture remaining string
@@ -1447,8 +1430,7 @@ class Calendar(object):
                     s = ''
 
         if parseStr:
-            debug and log.debug('found (qunits) [%s][%s][%s]',
-                                parseStr, chunk1, chunk2)
+            debug and logging.debug(f'found (qunits) [{parseStr}][{chunk1}][{chunk2}]')
             sourceTime = self._evalQUnits(parseStr, sourceTime)
 
         return s, sourceTime, bool(parseStr)
@@ -1521,7 +1503,7 @@ class Calendar(object):
                 s = ''
 
         if parseStr:
-            debug and log.debug(
+            debug and logging.debug(
                 'found (date3) [%s][%s][%s]', parseStr, chunk1, chunk2)
             sourceTime = self._evalDateStr(parseStr, sourceTime)
 
@@ -1559,7 +1541,7 @@ class Calendar(object):
                 s = ''
 
         if parseStr:
-            debug and log.debug(
+            debug and logging.debug(
                 'found (date) [%s][%s][%s]', parseStr, chunk1, chunk2)
             sourceTime = self._evalDateStd(parseStr, sourceTime)
 
@@ -1597,7 +1579,7 @@ class Calendar(object):
                 s = ''
 
         if parseStr:
-            debug and log.debug(
+            debug and logging.debug(
                 'found (day) [%s][%s][%s]', parseStr, chunk1, chunk2)
             sourceTime = self._evalDayStr(parseStr, sourceTime)
 
@@ -1621,7 +1603,7 @@ class Calendar(object):
         chunk1 = chunk2 = ''
 
         ctx = self.currentContext
-        log.debug('eval %s with context - %s, %s', s, ctx.hasDate, ctx.hasTime)
+        logging.debug(f'eval {s} with context - {ctx.hasDate}, {ctx.hasTime}')
 
         # Weekday
         m = self.ptc.CRE_WEEKDAY.search(s)
@@ -1640,7 +1622,7 @@ class Calendar(object):
                     s = ''
 
         if parseStr and not ctx.hasDate:
-            debug and log.debug(
+            debug and logging.debug(
                 'found (weekday) [%s][%s][%s]', parseStr, chunk1, chunk2)
             sourceTime = self._evalWeekday(parseStr, sourceTime)
 
@@ -1678,7 +1660,7 @@ class Calendar(object):
                 s = ''
 
         if parseStr:
-            debug and log.debug(
+            debug and logging.debug(
                 'found (time) [%s][%s][%s]', parseStr, chunk1, chunk2)
             sourceTime = self._evalTimeStr(parseStr, sourceTime)
 
@@ -1723,8 +1705,7 @@ class Calendar(object):
             s = '%s %s' % (chunk1, chunk2)
 
         if parseStr:
-            debug and log.debug('found (meridian) [%s][%s][%s]',
-                                parseStr, chunk1, chunk2)
+            debug and logging.debug(f'found (meridian) [{parseStr}][{chunk1}][{chunk2}]')
             sourceTime = self._evalMeridian(parseStr, sourceTime)
 
         return s, sourceTime, bool(parseStr)
@@ -1765,7 +1746,7 @@ class Calendar(object):
             s = '%s %s' % (chunk1, chunk2)
 
         if parseStr:
-            debug and log.debug(
+            debug and logging.debug(
                 'found (hms) [%s][%s][%s]', parseStr, chunk1, chunk2)
             sourceTime = self._evalTimeStd(parseStr, sourceTime)
 
@@ -1853,7 +1834,7 @@ class Calendar(object):
         @rtype:  tuple
         @return: tuple of: modified C{sourceTime} and the result flag/context
         """
-        debug and log.debug('parse()')
+        debug and logging.debug('parse()')
 
         datetimeString = re.sub(r'(\w)\.(\s)', r'\1\2', datetimeString)
         datetimeString = re.sub(r'(\w)[\'"](\s|$)', r'\1 \2', datetimeString)
@@ -1861,7 +1842,7 @@ class Calendar(object):
 
         if sourceTime:
             if isinstance(sourceTime, datetime.datetime):
-                debug and log.debug('coercing datetime to timetuple')
+                debug and logging.debug('coercing datetime to timetuple')
                 sourceTime = sourceTime.timetuple()
             else:
                 if not isinstance(sourceTime, time.struct_time) and \
@@ -1872,7 +1853,7 @@ class Calendar(object):
 
         with self.context() as ctx:
             s = datetimeString.lower().strip()
-            debug and log.debug('remainedString (before parsing): [%s]', s)
+            debug and logging.debug(f'remainedString (before parsing): [{s}]')
 
             while s:
                 for parseMeth in (self._partialParseModifier,
@@ -1893,13 +1874,12 @@ class Calendar(object):
                     # nothing matched
                     s = ''
 
-                debug and log.debug('hasDate: [%s], hasTime: [%s]',
-                                    ctx.hasDate, ctx.hasTime)
-                debug and log.debug('remainedString: [%s]', s)
+                debug and logging.debug(f'hasDate: [{ctx.hasDate}], hasTime: [{ctx.hasTime}]')
+                debug and logging.debug(f'remainedString: [{s}]')
 
             # String is not parsed at all
             if sourceTime is None:
-                debug and log.debug('not parsed [%s]', str(sourceTime))
+                debug and logging.debug(f'not parsed [{sourceTime}]')
                 sourceTime = time.localtime()
 
         if not isinstance(sourceTime, time.struct_time):
@@ -2038,9 +2018,9 @@ class Calendar(object):
             # Quantity + Units
             m = self.ptc.CRE_UNITS.search(inputString[startpos:])
             if m is not None:
-                debug and log.debug('CRE_UNITS matched')
+                debug and logging.debug('CRE_UNITS matched')
                 if self._UnitsTrapped(inputString[startpos:], m, 'units'):
-                    debug and log.debug('day suffix trapped by unit match')
+                    debug and logging.debug('day suffix trapped by unit match')
                 else:
 
                     if leftmost_match[1] == 0 or \
@@ -2059,9 +2039,9 @@ class Calendar(object):
             # Quantity + Units
             m = self.ptc.CRE_QUNITS.search(inputString[startpos:])
             if m is not None:
-                debug and log.debug('CRE_QUNITS matched')
+                debug and logging.debug('CRE_QUNITS matched')
                 if self._UnitsTrapped(inputString[startpos:], m, 'qunits'):
-                    debug and log.debug('day suffix trapped by qunit match')
+                    debug and logging.debug('day suffix trapped by qunit match')
                 else:
                     if leftmost_match[1] == 0 or \
                             leftmost_match[0] > m.start('qty') + startpos:
@@ -2178,8 +2158,7 @@ class Calendar(object):
                 # date while "next month" should
                 if m is not None and \
                         inputString[startpos:startpos + m.start()].strip() == '':
-                    debug and log.debug('CRE_UNITS_ONLY matched [%s]',
-                                        m.group())
+                    debug and logging.debug(f'CRE_UNITS_ONLY matched [{m.group()}]')
                     if leftmost_match[1] == 0 or \
                             leftmost_match[0] > m.start() + startpos:
                         leftmost_match[0] = m.start() + startpos
@@ -2787,7 +2766,7 @@ class Constants(object):
         the number of days in the month adjusting for leap year as needed
         """
         result = None
-        debug and log.debug('daysInMonth(%s, %s)', month, year)
+        debug and logging.debug(f'daysInMonth({month}, {year})')
         if month > 0 and month <= 12:
             result = self._DaysInMonthList[month - 1]
 

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -18,11 +18,3 @@ __contributors__ = ['Darshana Chhajed',
                     'Michael Lim (lim.ck.michael@gmail.com)',
                     'Bernd Zeimetz (bzed@debian.org)',
                     ]
-
-
-log = logging.getLogger('parsedatetime')
-echoHandler = logging.StreamHandler()
-echoFormatter = logging.Formatter('%(levelname)-8s %(message)s')
-log.addHandler(echoHandler)
-
-# log.setLevel(logging.DEBUG)


### PR DESCRIPTION
Strip out all explicit logging setup calls

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/bear/parsedatetime/270)
<!-- Reviewable:end -->
